### PR TITLE
fix(ev): discover BLE-only vehicles in discover_all_tesla_vehicles

### DIFF
--- a/custom_components/power_sync/automations/ev_charging_planner.py
+++ b/custom_components/power_sync/automations/ev_charging_planner.py
@@ -276,6 +276,17 @@ async def discover_all_tesla_vehicles(
     Searches the device registry for devices from known Tesla integrations
     and returns a list of all discovered vehicles with their VINs.
 
+    For users whose cars are only reachable via ESPHome Tesla BLE (no Fleet
+    API / Teslemetry / Tessie integration present), this also discovers
+    vehicles from the configured ``tesla_ble_entity_prefix`` setting. A BLE
+    vehicle is reported whenever its ``binary_sensor.{prefix}_status`` entity
+    exists in Home Assistant — the same live-presence signal that
+    ``EVVehiclesView`` uses for the mobile app. The returned ``vin`` for a
+    BLE vehicle is ``ble_{prefix}``, which downstream helpers
+    (``_resolve_vehicle_vin``, ``is_ev_plugged_in``, ``get_ev_battery_level``,
+    ``get_ev_location``) already handle via their existing
+    ``startswith("ble_")`` branches.
+
     Args:
         hass: Home Assistant instance
         config_entry: Config entry
@@ -284,10 +295,22 @@ async def discover_all_tesla_vehicles(
         List of dicts: [{"vin": str, "name": str, "device_id": str}, ...]
     """
     from homeassistant.helpers import device_registry as dr
+    from ..const import (
+        CONF_EV_PROVIDER,
+        CONF_TESLA_BLE_ENTITY_PREFIX,
+        DEFAULT_TESLA_BLE_ENTITY_PREFIX,
+        EV_PROVIDER_BOTH,
+        EV_PROVIDER_FLEET_API,
+        EV_PROVIDER_TESLA_BLE,
+        TESLA_BLE_BINARY_STATUS,
+    )
 
     device_registry = dr.async_get(hass)
     vehicles: List[Dict[str, Any]] = []
 
+    # Method 1 — HA device registry scan for Fleet API / Teslemetry / Tessie /
+    # Tesla Custom / legacy Tesla integration devices. Each such device
+    # publishes an identifier tuple ``(<integration>, <VIN>)``.
     for device in device_registry.devices.values():
         for identifier in device.identifiers:
             if len(identifier) >= 2 and identifier[0] in TESLA_INTEGRATIONS:
@@ -301,6 +324,39 @@ async def discover_all_tesla_vehicles(
                     })
                     _LOGGER.debug(f"Discovered Tesla vehicle: {device.name} (VIN: {id_str})")
                     break
+
+    # Method 2 — ESPHome Tesla BLE fallback. BLE-only setups don't register a
+    # Tesla-domain device in the HA registry (the ESPHome bridge registers under
+    # the "esphome" domain with no VIN identifier), so Method 1 never surfaces
+    # them. Discover each configured prefix whose ``binary_sensor.{prefix}_status``
+    # entity exists — that's PowerSync's canonical "BLE bridge is online" signal.
+    # Gated on ``ev_provider`` so fleet_api-only users never see spurious BLE
+    # vehicles from unrelated ESPHome devices that happen to match the default
+    # prefix.
+    opts = {**config_entry.data, **config_entry.options} if config_entry else {}
+    ev_provider = opts.get(CONF_EV_PROVIDER, EV_PROVIDER_FLEET_API)
+    if ev_provider in (EV_PROVIDER_TESLA_BLE, EV_PROVIDER_BOTH):
+        raw_prefix = opts.get(CONF_TESLA_BLE_ENTITY_PREFIX, DEFAULT_TESLA_BLE_ENTITY_PREFIX)
+        ble_prefixes = [p.strip() for p in raw_prefix.split(",") if p.strip()]
+        existing_vins = {v["vin"] for v in vehicles}
+        for prefix in ble_prefixes:
+            ble_vin = f"ble_{prefix}"
+            if ble_vin in existing_vins:
+                continue  # already reported (shouldn't happen, but defensive)
+            status_entity = TESLA_BLE_BINARY_STATUS.format(prefix=prefix)
+            if hass.states.get(status_entity) is None:
+                _LOGGER.debug(
+                    f"Tesla BLE discovery: skipping prefix '{prefix}' — "
+                    f"{status_entity} not found"
+                )
+                continue
+            display_name = f"Tesla BLE ({prefix})"
+            vehicles.append({
+                "vin": ble_vin,
+                "name": display_name,
+                "device_id": ble_vin,
+            })
+            _LOGGER.debug(f"Discovered Tesla BLE vehicle: {display_name}")
 
     _LOGGER.debug(f"Discovered {len(vehicles)} Tesla vehicle(s)")
     return vehicles


### PR DESCRIPTION
## Summary

Fixes **#23** — `discover_all_tesla_vehicles()` never surfaces BLE-only vehicles because it only scans the HA device registry for `TESLA_INTEGRATIONS` identifiers. ESPHome Tesla BLE bridges (PedroKTFC/esphome-tesla-ble etc.) register under the `esphome` domain with empty `identifiers[]`, so they fall through the scan even when they're fully functional.

Downstream effect: `MultiVehicleEvaluator.evaluate_all_vehicles()` and `_solar_surplus_switch_to_next_vehicle()` both see zero vehicles, silently breaking price-level charging and solar-surplus auto-switch for anyone running BLE without a Fleet API / Teslemetry / Tessie integration.

See #23 for full reproduction, impact analysis, and related findings.

## What this PR changes

- Adds a **Method 2 BLE fallback** inside `discover_all_tesla_vehicles()` that mirrors `EVVehiclesView._get_tesla_ble_vehicle()`'s live-presence signal:
  - Reads `CONF_TESLA_BLE_ENTITY_PREFIX` (comma-separated prefix list).
  - For each prefix whose `binary_sensor.{prefix}_status` entity exists in HA, appends a vehicle dict with `vin=f\"ble_{prefix}\"`, `name=\"Tesla BLE ({prefix})\"`, `device_id=f\"ble_{prefix}\"`.
- Gated on `ev_provider in (tesla_ble, both)` so `fleet_api`-only users never see spurious BLE vehicles.
- Uses the same `ble_{prefix}` vehicle_id convention already produced by `EVVehiclesView._get_tesla_ble_vehicle()`, which keeps the two discovery paths aligned.
- No changes to function signatures or return shape — still `List[Dict[{vin, name, device_id}]]`.
- No dedup logic needed: BLE vins start with `ble_` and real VINs are 17 chars, so the two namespaces can't collide. A defensive `existing_vins` check is included anyway.

## Why this is safe for downstream callers

The returned `vin` for a BLE vehicle is `ble_{prefix}`, which every downstream helper the planner calls already handles correctly:

| Helper | File:line | BLE handling |
|---|---|---|
| `_resolve_vehicle_vin` | `ev_charging_planner.py:2791` | `if vehicle_id.startswith(\"ble_\"): return vehicle_id` |
| `is_ev_plugged_in` | `ev_charging_planner.py:476` | `if vehicle_vin and vehicle_vin.startswith(\"ble_\"): ...` — reads `binary_sensor.{prefix}_charge_flap` |
| `get_ev_battery_level` | `ev_charging_planner.py:563` | Same `.startswith(\"ble_\")` branch — reads `sensor.{prefix}_battery_level` |
| `get_ev_location` | `ev_charging_planner.py:235` | Same branch — reads `switch.{prefix}_charger` as a \"was here\" proxy |

So this PR makes existing correct logic reachable, rather than introducing new execution paths that could go wrong.

## Diff size

**56 insertions, 0 deletions**, single file: `custom_components/power_sync/automations/ev_charging_planner.py`. The only additions are the docstring expansion, six imports from `..const`, and the new \"Method 2\" block. Method 1 is untouched.

## Verified working

Tested on my own HA instance, which has:

- 2 Model Y's paired via PedroKTFC v2026.3.0 (ESP32-S3 N16R8, both online)
- PowerSync configured with `ev_provider: tesla_ble`, `tesla_ble_entity_prefix: ble_slater,ble_phoenix`
- **No Teslemetry / Fleet API / Tessie** — I removed Teslemetry earlier today and the symptom manifested immediately as \"No Tesla vehicles discovered for multi-vehicle evaluation\" on every poll.

### Before (upstream `main`)

```
$ curl -sX POST -H 'Authorization: Bearer $LLT' \
      http://<ha>:8123/api/power_sync/ev/vehicles/sync | jq '.vehicles[].vehicle_id'
\"ble_ble_slater\"
\"ble_ble_phoenix\"
```

HA log (same moment):
```
DEBUG [custom_components.power_sync.automations.ev_charging_planner] Discovered 0 Tesla vehicle(s)
DEBUG [custom_components.power_sync.automations.ev_charging_planner] No Tesla vehicles discovered for multi-vehicle evaluation
```

### After (this branch)

The sync endpoint continues to return the 2 BLE vehicles, **and** the internal `discover_all_tesla_vehicles()` call now returns the same two vehicles with `ble_ble_slater` / `ble_ble_phoenix` vins so the multi-vehicle evaluator and solar-surplus auto-switch can act on them.

## Not changed / out of scope

The companion issue (#23) lists three adjacent rough edges I found while auditing BLE paths — default-VIN comma-prefix bug in `is_ev_plugged_in`/`get_ev_battery_level`/`get_ev_location`, dead-code `tesla_ble`/`tesla_bluetooth` domain check at line 4878, and 7 duplicated device-registry scan loops that want a shared helper. None of those are touched in this PR — happy to follow up separately if you'd like.

## Test plan for reviewers

- [ ] `python -m py_compile custom_components/power_sync/automations/ev_charging_planner.py` (done locally, passes)
- [ ] Verify Method 1 behaviour unchanged for Fleet API / Teslemetry / Tessie users (only new code runs when `ev_provider` is `tesla_ble` or `both`)
- [ ] Verify Method 2 behaviour for a `tesla_ble` user with a single prefix that resolves
- [ ] Verify Method 2 behaviour for a `tesla_ble` user with a comma-separated prefix list (both resolve)
- [ ] Verify Method 2 behaviour when `binary_sensor.{prefix}_status` is missing (vehicle skipped, logged at DEBUG)
- [ ] Verify `both` mode returns Fleet API vehicles AND BLE vehicles in a hybrid setup