### PR TITLE
fix(tesla): site_info cache invalidation, PowerSync token routing, Fleet API provider persistence

### DIFF
--- a/custom_components/power_sync/config_flow.py
+++ b/custom_components/power_sync/config_flow.py
@@ -2462,6 +2462,24 @@ class PowerSyncOptionsFlow(config_entries.OptionsFlow):
                 _LOGGER.error("Cannot restore export rule - Fleet API token not available")
                 return
             base_url = FLEET_API_BASE_URL
+        elif api_provider == TESLA_PROVIDER_POWERSYNC:
+            # PowerSync.cc proxy users store their `psync_...` token in the
+            # same CONF_TESLEMETRY_API_TOKEN slot, but it must be sent to
+            # the PowerSync proxy base URL, not the Teslemetry base URL.
+            # Prior code fell through to the `else` branch and hit the
+            # wrong endpoint — the call always 401'd silently and the
+            # export rule was never restored after curtailment.
+            # Guard `.startswith` with `isinstance(api_token, str)` so a
+            # non-string truthy value from storage doesn't raise
+            # AttributeError before the try block below.
+            api_token = self.config_entry.data.get(CONF_TESLEMETRY_API_TOKEN)
+            if not isinstance(api_token, str) or not api_token.startswith("psync_"):
+                _LOGGER.error(
+                    "Cannot restore export rule - PowerSync token missing or "
+                    "not a valid psync_ token"
+                )
+                return
+            base_url = POWERSYNC_API_BASE_URL
         else:
             # Teslemetry
             api_token = self.config_entry.data.get(CONF_TESLEMETRY_API_TOKEN)

--- a/custom_components/power_sync/config_flow.py
+++ b/custom_components/power_sync/config_flow.py
@@ -1906,7 +1906,14 @@ class PowerSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 if validation_result["success"]:
                     # Store empty Teslemetry token (we'll use Fleet API in __init__.py)
-                    self._teslemetry_data = {CONF_TESLEMETRY_API_TOKEN: ""}
+                    # AND persist the provider choice so that on HA restart the
+                    # integration remembers we picked Fleet API instead of
+                    # defaulting back to Teslemetry (which would then 401 on
+                    # the empty token and break the Tesla coordinator).
+                    self._teslemetry_data = {
+                        CONF_TESLEMETRY_API_TOKEN: "",
+                        CONF_TESLA_API_PROVIDER: TESLA_PROVIDER_FLEET_API,
+                    }
                     self._tesla_sites = validation_result.get("sites", [])
                     return await self.async_step_site_selection()
                 else:

--- a/custom_components/power_sync/coordinator.py
+++ b/custom_components/power_sync/coordinator.py
@@ -1756,6 +1756,15 @@ class TeslaEnergyCoordinator(DataUpdateCoordinator):
         entities reading from the cache don't display stale values for
         up to six hours until the next natural refresh.
         """
+        # Clear the cached payload itself, not just the timestamp.
+        # async_get_site_info() checks `if self._site_info_cache and age
+        # <= 21600` — resetting _site_info_last_fetch to 0 only invalidates
+        # via the age check when time.monotonic() > 21600, i.e. after HA
+        # has been running 6+ hours. On shorter uptimes the age check
+        # still passes (time.monotonic() - 0 is small), and the stale
+        # _site_info_cache is returned anyway. Clearing _site_info_cache
+        # makes the first half of the `and` fail unconditionally.
+        self._site_info_cache = None
         self._site_info_last_fetch = 0
         self._site_info_fetch_failed = False
         _LOGGER.debug("Tesla site_info cache invalidated — next read will refetch")


### PR DESCRIPTION
Three small Tesla integration bug fixes surfaced by a CodeRabbit audit on a fork. Each is an atomic commit and they're independent — happy to split into 3 PRs if you prefer.

## 1. `coordinator.py` — `invalidate_site_info_cache()` only resets the timestamp, not the cached payload

**Bug**

\`invalidate_site_info_cache()\` is called after every write that modifies site_info-level fields (backup reserve, operation mode, grid export rule, grid charging, storm mode, off-grid EV reserve, VPP enrollment). The intent is "force the next read to refetch from Tesla". In practice it only resets \`_site_info_last_fetch\` to 0 and clears the fetch-failed flag — it does **not** clear the cached payload itself.

The cache-hit check in \`async_get_site_info()\` is:

\`\`\`python
if self._site_info_cache and (time.monotonic() - self._site_info_last_fetch) <= 21600:
    return self._site_info_cache
\`\`\`

Setting \`_site_info_last_fetch = 0\` makes the age calculation \`time.monotonic() - 0\`. \`time.monotonic()\` measures seconds since some arbitrary reference (typically process start), so during the first 6 hours of HA uptime this value is **well under 21600** — the age check passes, and the un-cleared \`_site_info_cache\` is returned anyway.

**Symptom**

User changes a setting via the mobile app → PowerSync writes to Tesla → calls \`invalidate_site_info_cache()\` → next sensor read returns the old value. Dashboard shows the stale backup reserve / operation mode / grid export rule for **up to 6 hours** until the natural refresh cycle kicks in. On HA hosts that reboot more often than once every 6 hours, users see this as "settings don't actually persist".

**Fix**

Also clear \`self._site_info_cache = None\` in addition to resetting the timestamp. The first half of the \`and\` condition then fails unconditionally, forcing a refetch.

## 2. `config_flow.py` — `_restore_export_rule()` sends PowerSync proxy tokens to the wrong base URL

**Bug**

\`_restore_export_rule()\` is called when the user disables solar curtailment to flip Tesla's export rule back to \`battery_ok\`. The provider selection was a two-way if/else covering only Fleet API and Teslemetry:

\`\`\`python
if api_provider == TESLA_PROVIDER_FLEET_API:
    ...Fleet API token from tesla_fleet integration...
    base_url = FLEET_API_BASE_URL
else:
    ...CONF_TESLEMETRY_API_TOKEN...
    base_url = TESLEMETRY_API_BASE_URL
\`\`\`

PowerSync.cc proxy users (with \`api_provider = TESLA_PROVIDER_POWERSYNC\` and a \`psync_...\` token in the reused \`CONF_TESLEMETRY_API_TOKEN\` slot) fall into the \`else\` branch and hit \`TESLEMETRY_API_BASE_URL\` with a token the wrong server doesn't recognize.

**Symptom**

For PowerSync.cc proxy users, every "disable curtailment" call silently 401s. The export rule is never actually restored to \`battery_ok\` after curtailment ends — solar export stays blocked at the inverter level until manual intervention.

**Fix**

Add an explicit \`elif api_provider == TESLA_PROVIDER_POWERSYNC\` branch that uses \`POWERSYNC_API_BASE_URL\`. Also guards \`startswith\` with \`isinstance(api_token, str)\` so a malformed non-string token doesn't raise \`AttributeError\` outside the try block (defensive pattern matching the rest of this file).

## 3. `config_flow.py` — Fleet API provider not persisted during initial setup

**Bug**

When the Fleet API path succeeds during initial Tesla setup, the flow stores:

\`\`\`python
self._teslemetry_data = {CONF_TESLEMETRY_API_TOKEN: ""}
\`\`\`

This dict gets merged into the final \`config_entry.data\`. The empty Teslemetry token slot is persisted, but the provider choice itself (\`CONF_TESLA_API_PROVIDER: TESLA_PROVIDER_FLEET_API\`) is **never written**. On HA restart, the integration reads:

\`\`\`python
api_provider = entry.data.get(CONF_TESLA_API_PROVIDER, TESLA_PROVIDER_TESLEMETRY)
\`\`\`

The default kicks in, the integration "forgets" Fleet API was selected, and falls back to Teslemetry. Teslemetry code paths then read the empty token and 401 on every call.

The other two provider paths persist the choice correctly — Teslemetry via \`user_input\` (the form posts the key) and PowerSync via an explicit dict assignment. The Fleet API branch is the odd one out.

**Symptom**

User picks Fleet API during setup → everything works → HA restarts → Tesla coordinator silently switches to Teslemetry mode and 401s on every API call. User sees stale/unknown values across the entire Powerwall section after restart, with no obvious cause in the logs.

**Fix**

Add \`CONF_TESLA_API_PROVIDER: TESLA_PROVIDER_FLEET_API\` to the \`_teslemetry_data\` dict so the provider choice survives restart.

## Validation

- \`python -m compileall -q custom_components/power_sync/coordinator.py custom_components/power_sync/config_flow.py\` — passes
- All 3 commits cherry-picked cleanly onto current \`main\` (2.11.10)
- Each commit is independent and reverts cleanly if you prefer to take a subset

## Test plan

- [ ] Manual: install Fleet API setup path → restart HA → verify Tesla coordinator still authenticates against Fleet API base URL (not Teslemetry)
- [ ] Manual: install PowerSync proxy setup path → enable solar curtailment → disable curtailment → verify export rule successfully restored to \`battery_ok\` (PowerSync proxy 200 in logs, no 401)
- [ ] Manual: change backup_reserve via mobile app → verify HA dashboard reflects the new value within one sync cycle (<60s) instead of waiting 6 hours