### PR TITLE
fix(sensor): correct load forecast unit and reduce attribute size

### DIFF
--- a/custom_components/power_sync/sensor.py
+++ b/custom_components/power_sync/sensor.py
@@ -1486,14 +1486,17 @@ LP_FORECAST_SENSORS: tuple[PowerSyncSensorEntityDescription, ...] = (
     PowerSyncSensorEntityDescription(
         key=SENSOR_TYPE_LP_LOAD_FORECAST,
         name="Load Forecast",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
         suggested_display_precision=1,
         icon="mdi:home-lightning-bolt",
         value_fn=lambda data: data.get("load_forecast_kwh") if data and data.get("available") else None,
         attr_fn=lambda data: {
             "peak_kw": data.get("load_peak_kw"),
-            "forecast_values_kw": data.get("load_forecast"),
+            "forecast_hours": len(data.get("load_forecast", [])) // 2,
+            "forecast_min_kw": round(min(data.get("load_forecast", [0])), 2) if data.get("load_forecast") else None,
+            "forecast_max_kw": round(max(data.get("load_forecast", [0])), 2) if data.get("load_forecast") else None,
+            "forecast_avg_kw": round(sum(data.get("load_forecast", [0])) / max(1, len(data.get("load_forecast", [1]))), 2) if data.get("load_forecast") else None,
         } if data and data.get("available") else {},
     ),
     PowerSyncSensorEntityDescription(


### PR DESCRIPTION
sensor.power_sync_home_load_forecast has two issues:
1. Unit is KILO_WATT_HOUR but value is power — should be KILO_WATT. Breaks long-term statistics.
2. Attributes store full 48h forecast array (>16KB), exceeding HA recorder limit.

- Change unit to kW, device_class to POWER
- Replace raw array with summary stats (min/max/avg/peak)

**1 file changed:** sensor.py