### PR TITLE
fix(inverters): Sungrow self._model typo and GoodWe zero-PV return

### DIFF
--- a/custom_components/power_sync/inverters/goodwe.py
+++ b/custom_components/power_sync/inverters/goodwe.py
@@ -419,12 +419,12 @@ class GoodWeController(InverterController):
             # Calculate total power
             pv1 = attrs.get("pv1_power", 0)
             pv2 = attrs.get("pv2_power", 0)
-            power_output = pv1 + pv2 if pv1 or pv2 else None
+            power_output = pv1 + pv2 if pv1 is not None and pv2 is not None else None
 
             self._last_state = InverterState(
                 status=status,
                 is_curtailed=is_curtailed,
-                power_output_w=float(power_output) if power_output else None,
+                power_output_w=float(power_output) if power_output is not None else None,
                 attributes=attrs,
             )
 

--- a/custom_components/power_sync/inverters/sungrow.py
+++ b/custom_components/power_sync/inverters/sungrow.py
@@ -435,7 +435,7 @@ class SungrowController(InverterController):
                 _LOGGER.debug(f"Sungrow power: {attrs['dc_power']}W")
             else:
                 # This can happen during concurrent reads or if inverter is offline
-                _LOGGER.debug(f"Failed to read power register for model {self._model}")
+                _LOGGER.debug(f"Failed to read power register for model {self.model}")
 
             # Read daily yield
             daily_result = await self._read_register_from_map("daily_yield")


### PR DESCRIPTION
Two one-line inverter fixes:

1. **sungrow.py:438** — `self._model` should be `self.model` (base class attribute). Causes AttributeError when logging power read failures.
2. **goodwe.py:422** — `pv1 or pv2` evaluates to falsy when PV is zero, returning None instead of 0. Changed to `is not None` check.

**2 files changed, ~4 lines each**