### PR TITLE
fix(amber): use configured timezone instead of hardcoded AEST

### DIFF
--- a/custom_components/power_sync/tariff_converter.py
+++ b/custom_components/power_sync/tariff_converter.py
@@ -1433,10 +1433,12 @@ def _apply_network_tariff_library(
 
             # Build a datetime for this period (use today's date)
             # The library uses interval_time for TOU period detection
-            now = datetime.now()
-            interval_time = datetime(
-                now.year, now.month, now.day, hour, minute,
-                tzinfo=dt_util.DEFAULT_TIME_ZONE
+            now = dt_util.now()
+            interval_time = now.replace(
+                hour=hour,
+                minute=minute,
+                second=0,
+                microsecond=0,
             )
 
             # Convert wholesale $/kWh to $/MWh for the library

--- a/custom_components/power_sync/tariff_converter.py
+++ b/custom_components/power_sync/tariff_converter.py
@@ -811,8 +811,9 @@ def _build_rolling_24h_tariff(
         aus_tz = detected_tz
         _LOGGER.info("Using auto-detected timezone: %s", aus_tz)
     else:
-        aus_tz = ZoneInfo("Australia/Sydney")
-        _LOGGER.warning("Timezone detection failed, falling back to Australia/Sydney")
+        from homeassistant.util import dt as dt_util
+        aus_tz = dt_util.DEFAULT_TIME_ZONE
+        _LOGGER.warning("Timezone detection failed, falling back to HA configured timezone: %s", aus_tz)
 
     now = datetime.now(aus_tz)
     today = now.date()
@@ -1403,6 +1404,7 @@ def _apply_network_tariff_library(
         Modified tariff with retail prices from library
     """
     from datetime import datetime, timezone, timedelta
+    from homeassistant.util import dt as dt_util
 
     # Map distributors to library module names
     # CitiPower and United Energy use the generic Victoria module
@@ -1434,7 +1436,7 @@ def _apply_network_tariff_library(
             now = datetime.now()
             interval_time = datetime(
                 now.year, now.month, now.day, hour, minute,
-                tzinfo=timezone(timedelta(hours=10))  # AEST
+                tzinfo=dt_util.DEFAULT_TIME_ZONE
             )
 
             # Convert wholesale $/kWh to $/MWh for the library

--- a/custom_components/power_sync/tariff_utils.py
+++ b/custom_components/power_sync/tariff_utils.py
@@ -13,6 +13,8 @@ import sys
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
+from homeassistant.util import dt as dt_util
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -88,7 +90,7 @@ def compute_avg_daily_tariff(
     try:
         from aemo_to_tariff import spot_to_tariff
 
-        now = datetime.now(tz=timezone(timedelta(hours=10)))  # AEST
+        now = dt_util.now()  # Use HA configured timezone instead of hardcoded AEST
         base_date = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
         total = 0.0


### PR DESCRIPTION
Two files hardcode AEST timezone which breaks DST for VIC/NSW/TAS users:

1. **tariff_utils.py** — replaced `timezone(timedelta(hours=10))` with `dt_util.now()`
2. **tariff_converter.py** — replaced `ZoneInfo('Australia/Sydney')` fallback with `dt_util.DEFAULT_TIME_ZONE`, and `datetime.now()` with `dt_util.now()` for HA-local date

**2 files changed**