### PR TITLE
fix(reliability): GoodWe error propagation and coordinator TypeError

### DIFF
--- a/custom_components/power_sync/inverters/goodwe_battery.py
+++ b/custom_components/power_sync/inverters/goodwe_battery.py
@@ -26,17 +26,24 @@ class GoodWeBatteryController:
         """Connect to inverter and auto-detect model family."""
         import goodwe
 
-        async with self._lock:
-            self._inverter = await goodwe.connect(
-                host=self.host, port=self.port, comm_addr=self.comm_addr
-            )
-            _LOGGER.info(
-                "Connected to GoodWe %s (SN: %s, rated: %sW)",
-                self._inverter.model_name,
-                self._inverter.serial_number,
-                self._inverter.rated_power,
-            )
-            return True
+        try:
+            async with self._lock:
+                self._inverter = await goodwe.connect(
+                    host=self.host, port=self.port, comm_addr=self.comm_addr
+                )
+                if self._inverter is None:
+                    _LOGGER.error("GoodWe connect returned None for %s", self.host)
+                    return False
+                _LOGGER.info(
+                    "Connected to GoodWe %s (SN: %s, rated: %sW)",
+                    self._inverter.model_name,
+                    self._inverter.serial_number,
+                    self._inverter.rated_power,
+                )
+                return True
+        except Exception as err:
+            _LOGGER.error("GoodWe connect failed for %s: %s", self.host, err)
+            return False
 
     async def get_runtime_data(self) -> dict[str, Any]:
         """Read runtime data from inverter.
@@ -85,33 +92,45 @@ class GoodWeBatteryController:
         """Force charge from grid using ECO_CHARGE mode."""
         import goodwe
 
-        await self._inverter.set_operation_mode(
-            goodwe.OperationMode.ECO_CHARGE,
-            eco_mode_power=power_pct,
-            eco_mode_soc=soc_target,
-        )
-        _LOGGER.info("GoodWe force charge: power=%d%%, target_soc=%d%%", power_pct, soc_target)
-        return True
+        try:
+            await self._inverter.set_operation_mode(
+                goodwe.OperationMode.ECO_CHARGE,
+                eco_mode_power=power_pct,
+                eco_mode_soc=soc_target,
+            )
+            _LOGGER.info("GoodWe force charge: power=%d%%, target_soc=%d%%", power_pct, soc_target)
+            return True
+        except Exception as err:
+            _LOGGER.error("GoodWe force charge failed: %s", err)
+            return False
 
     async def force_discharge(self, power_pct: int = 100, soc_floor: int = 10) -> bool:
         """Force discharge to grid using ECO_DISCHARGE mode."""
         import goodwe
 
-        await self._inverter.set_operation_mode(
-            goodwe.OperationMode.ECO_DISCHARGE,
-            eco_mode_power=power_pct,
-            eco_mode_soc=soc_floor,
-        )
-        _LOGGER.info("GoodWe force discharge: power=%d%%, floor_soc=%d%%", power_pct, soc_floor)
-        return True
+        try:
+            await self._inverter.set_operation_mode(
+                goodwe.OperationMode.ECO_DISCHARGE,
+                eco_mode_power=power_pct,
+                eco_mode_soc=soc_floor,
+            )
+            _LOGGER.info("GoodWe force discharge: power=%d%%, floor_soc=%d%%", power_pct, soc_floor)
+            return True
+        except Exception as err:
+            _LOGGER.error("GoodWe force discharge failed: %s", err)
+            return False
 
     async def restore_normal(self) -> bool:
         """Restore to normal (GENERAL) operation mode."""
         import goodwe
 
-        await self._inverter.set_operation_mode(goodwe.OperationMode.GENERAL)
-        _LOGGER.info("GoodWe restored to GENERAL mode")
-        return True
+        try:
+            await self._inverter.set_operation_mode(goodwe.OperationMode.GENERAL)
+            _LOGGER.info("GoodWe restored to GENERAL mode")
+            return True
+        except Exception as err:
+            _LOGGER.error("GoodWe restore to GENERAL mode failed: %s", err)
+            return False
 
     async def set_backup_reserve(self, percent: int) -> bool:
         """Set backup reserve (minimum SOC).

--- a/custom_components/power_sync/optimization/coordinator.py
+++ b/custom_components/power_sync/optimization/coordinator.py
@@ -977,20 +977,18 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     if battery and hasattr(battery, "force_charge") and self.battery_system not in ("tesla",):
                         extend_mins = self._config.interval_minutes + 5
                         try:
-                            # Pass _extend_hardware flag so the service handler
-                            # only re-issues Modbus writes without setting a new
-                            # expiry timer (we manage the timer here).
+                            # Re-issue the Modbus command to extend the
+                            # hardware timer. Inverter implementations
+                            # only accept duration_minutes and power_w.
                             if force_type == "charge":
                                 await battery.force_charge(
                                     duration_minutes=extend_mins,
                                     power_w=action.power_w,
-                                    _extend_hardware=True,
                                 )
                             else:
                                 await battery.force_discharge(
                                     duration_minutes=extend_mins,
                                     power_w=action.power_w,
-                                    _extend_hardware=True,
                                 )
                             _LOGGER.debug(
                                 "Optimizer: re-issued Modbus %s command for hardware timer extension (%dmin)",


### PR DESCRIPTION
Two critical reliability fixes:

1. **goodwe_battery.py** — `force_charge()`, `force_discharge()`, `restore_normal()`, and `connect()` unconditionally return True even on exception. Wrapped in try/except, return False on failure. Added None check after connect().

2. **coordinator.py:983-994** — Optimizer passes `_extend_hardware=True` kwarg to force_charge/force_discharge, but no inverter implementation accepts it. Causes TypeError on every hardware timer extension. Removed the unsupported kwarg.

**2 files changed**