### PR TITLE
fix(frontend): only show EV icon when vehicle entity is available

### DIFF
--- a/custom_components/power_sync/frontend/power-sync-energy-flow.js
+++ b/custom_components/power_sync/frontend/power-sync-energy-flow.js
@@ -1271,11 +1271,18 @@
 
       const vehicles = evSlots
         .map((slot) => {
-          const configured = !!(slot.powerEntity || slot.batteryEntity || slot.chargeSwitchEntity || slot.presenceEntity);
+          const hasConfiguredEntity = !!(slot.powerEntity || slot.batteryEntity || slot.chargeSwitchEntity || slot.presenceEntity);
           const powerState = this._entityState(slot.powerEntity);
           const batteryState = this._entityState(slot.batteryEntity);
           const switchState = this._entityState(slot.chargeSwitchEntity);
           const presenceState = this._entityState(slot.presenceEntity);
+          // Only consider configured if at least one entity exists in HA and
+          // is not unavailable/unknown — prevents phantom EV icons when the
+          // card config references entities that don't exist.
+          const anyEntityAvailable = [powerState, batteryState, switchState, presenceState].some(
+            (s) => s != null && s.state !== 'unavailable' && s.state !== 'unknown'
+          );
+          const configured = hasConfiguredEntity && anyEntityAvailable;
           const batteryPct = [
             toPct(batteryState, Number.NaN),
             toPct(powerState, Number.NaN),


### PR DESCRIPTION
Dashboard energy flow card shows 2 vehicles when only 1 is home. The card renders EV icons whenever entities are configured, regardless of availability.

- Check entity state before rendering — require at least one entity to have a valid (non-unavailable/unknown) state

Fixes #58

**1 file changed:** frontend/power-sync-energy-flow.js