### PR TITLE
fix(translations): remove inline URLs and add CONFIG_SCHEMA for hassfest

### DIFF
--- a/custom_components/power_sync/__init__.py
+++ b/custom_components/power_sync/__init__.py
@@ -17,6 +17,7 @@ DISCREPANCY_ALERT_COOLDOWN = timedelta(minutes=30)
 DISCREPANCY_ALERT_DAILY_MAX = 4
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import Platform, CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -893,6 +894,8 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.BINARY_SENSOR,
 ]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 # Storage version for persisting data across HA restarts
 STORAGE_VERSION = 1

--- a/custom_components/power_sync/strings.json
+++ b/custom_components/power_sync/strings.json
@@ -521,7 +521,7 @@
           "teslemetry_api_token": "API token"
         },
         "data_description": {
-          "teslemetry_api_token": "Get a token from [teslemetry.com](https://teslemetry.com). Paste the full token string."
+          "teslemetry_api_token": "Get a token from teslemetry.com. Paste the full token string."
         },
         "submit": "Connect"
       },
@@ -532,7 +532,7 @@
           "teslemetry_api_token": "PowerSync token"
         },
         "data_description": {
-          "teslemetry_api_token": "Open [{auth_url}]({auth_url}) in a browser, sign in with Tesla, and copy the `psync_` token. Your Tesla credentials are never shared with PowerSync."
+          "teslemetry_api_token": "Open {auth_url} in a browser, sign in with Tesla, and copy the psync_ token. Your Tesla credentials are never shared with PowerSync."
         },
         "submit": "Connect"
       },

--- a/custom_components/power_sync/translations/en.json
+++ b/custom_components/power_sync/translations/en.json
@@ -521,7 +521,7 @@
           "teslemetry_api_token": "API token"
         },
         "data_description": {
-          "teslemetry_api_token": "Get a token from [teslemetry.com](https://teslemetry.com). Paste the full token string."
+          "teslemetry_api_token": "Get a token from teslemetry.com. Paste the full token string."
         },
         "submit": "Connect"
       },
@@ -532,7 +532,7 @@
           "teslemetry_api_token": "PowerSync token"
         },
         "data_description": {
-          "teslemetry_api_token": "Open [{auth_url}]({auth_url}) in a browser, sign in with Tesla, and copy the `psync_` token. Your Tesla credentials are never shared with PowerSync."
+          "teslemetry_api_token": "Open {auth_url} in a browser, sign in with Tesla, and copy the psync_ token. Your Tesla credentials are never shared with PowerSync."
         },
         "submit": "Connect"
       },


### PR DESCRIPTION
## Summary
Fixes HACS Validation / validate-hassfest failure.

## Changes
- Removed markdown-style inline URLs from `teslemetry_api_token` descriptions in `strings.json` and `translations/en.json`
- Added `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` to `__init__.py`

## Errors Fixed
```
[ERROR] [TRANSLATIONS] Invalid strings.json: the string should not contain URLs
[WARNING] [CONFIG_SCHEMA] Integrations which implement async_setup must define CONFIG_SCHEMA
```