### PR TITLE
fix(sungrow): use self.model instead of self._model in debug log

### DIFF
--- a/custom_components/power_sync/inverters/sungrow.py
+++ b/custom_components/power_sync/inverters/sungrow.py
@@ -435,7 +435,7 @@ class SungrowController(InverterController):
                 _LOGGER.debug(f"Sungrow power: {attrs['dc_power']}W")
             else:
                 # This can happen during concurrent reads or if inverter is offline
-                _LOGGER.debug(f"Failed to read power register for model {self._model}")
+                _LOGGER.debug(f"Failed to read power register for model {self.model}")
 
             # Read daily yield
             daily_result = await self._read_register_from_map("daily_yield")


### PR DESCRIPTION
## Summary
One-line fix — `self._model` is undefined on the Sungrow controller. The correct attribute is `self.model` (used elsewhere at lines 757 and 837).

## Changes
- `inverters/sungrow.py`: `self._model` → `self.model` in debug log