### PR TITLE
fix(amber): use HA configured timezone instead of hardcoded AEST

### DIFF
--- a/custom_components/power_sync/tariff_converter.py
+++ b/custom_components/power_sync/tariff_converter.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+
+from homeassistant.util import dt as dt_util
 import logging
 from typing import Any
 
@@ -1420,6 +1422,7 @@ def _apply_network_tariff_library(
         rates = tariff["energy_charges"][season].get("rates", {})
         modified_count = 0
 
+        anchor_now = dt_util.now()  # Anchor once to avoid midnight crossing inconsistency
         for period, price in list(rates.items()):
             # Extract hour and minute from PERIOD_HH_MM
             try:
@@ -1431,10 +1434,8 @@ def _apply_network_tariff_library(
 
             # Build a datetime for this period (use today's date)
             # The library uses interval_time for TOU period detection
-            now = datetime.now()
-            interval_time = datetime(
-                now.year, now.month, now.day, hour, minute,
-                tzinfo=timezone(timedelta(hours=10))  # AEST
+            interval_time = anchor_now.replace(
+                hour=hour, minute=minute, second=0, microsecond=0,
             )
 
             # Convert wholesale $/kWh to $/MWh for the library

--- a/custom_components/power_sync/tariff_utils.py
+++ b/custom_components/power_sync/tariff_utils.py
@@ -11,7 +11,9 @@ import io
 import logging
 import sys
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,7 +90,7 @@ def compute_avg_daily_tariff(
     try:
         from aemo_to_tariff import spot_to_tariff
 
-        now = datetime.now(tz=timezone(timedelta(hours=10)))  # AEST
+        now = dt_util.now()  # Uses HA configured timezone
         base_date = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
         total = 0.0


### PR DESCRIPTION
## Summary
Replaces `timedelta(hours=10)` AEST hardcoding with `dt_util.now()` which respects the user's HA configured timezone.

## Changes
- `tariff_converter.py`: Uses `dt_util.now()` anchored outside the loop
- `tariff_utils.py`: Uses `dt_util.now()` instead of hardcoded offset

## Impact
The +10 offset doesn't handle daylight saving (AEDT is +11) and is wrong for non-Sydney users (Perth +8, Brisbane +10 no DST, Adelaide +9:30).