### PR TITLE
fix(automations): use timezone-aware datetime.now() in fallback path

### DIFF
--- a/custom_components/power_sync/automations/__init__.py
+++ b/custom_components/power_sync/automations/__init__.py
@@ -6,7 +6,7 @@ Automations are stored using HA's Store helper for persistence.
 """
 
 import logging
-from datetime import datetime, time as dt_time
+from datetime import datetime, time as dt_time, timezone
 from typing import Optional, List, Dict, Any
 import json
 
@@ -471,7 +471,7 @@ class AutomationEngine:
             user_tz = ZoneInfo(user_timezone)
             current_time_local = datetime.now(user_tz)
         except Exception:
-            current_time_local = datetime.now()
+            current_time_local = datetime.now(timezone.utc)
             user_timezone = "UTC"
 
         state: Dict[str, Any] = {


### PR DESCRIPTION
## Summary
The ZoneInfo fallback path creates a naive datetime via `datetime.now()` when timezone parsing fails. Since the fallback explicitly sets `user_timezone = "UTC"`, the datetime should also be UTC-aware.

## Changes
- `automations/__init__.py`: `datetime.now()` → `datetime.now(timezone.utc)`
- Added `timezone` to datetime imports