### PR TITLE
fix(frontend): add staleness check to EV presence detection

### DIFF
--- a/custom_components/power_sync/frontend/power-sync-energy-flow.js
+++ b/custom_components/power_sync/frontend/power-sync-energy-flow.js
@@ -1101,6 +1101,20 @@
     if (!entityState) return false;
     const state = String(entityState.state || '').trim().toLowerCase();
     if (!state || ['unknown', 'unavailable', 'none', 'null'].includes(state)) return false;
+
+    // Stale check for BLE/sensor entities: if entity hasn't updated in 15 min,
+    // treat as absent. BLE entities keep their last state when vehicle leaves range.
+    // Skip staleness for person/device_tracker/input_boolean which update infrequently.
+    const entityId = entityState.entity_id || '';
+    const isBleOrSensor = entityId.startsWith('binary_sensor.') || entityId.startsWith('sensor.');
+    if (isBleOrSensor) {
+      const lastUpdated = entityState.last_updated || entityState.last_changed;
+      if (lastUpdated) {
+        const ageMs = Date.now() - new Date(lastUpdated).getTime();
+        if (ageMs > 15 * 60 * 1000) return false;  // 15 min stale threshold
+      }
+    }
+
     if (['on', 'home', 'present', 'true', 'occupied', 'detected'].includes(state)) return true;
     // EV charging states that indicate vehicle is present (plugged in)
     if (['charging', 'complete', 'connected', 'stopped', 'ready', 'waiting', 'paused', 'full'].includes(state)) return true;


### PR DESCRIPTION
## Summary
BLE entities retain their last state when vehicle goes out of range, causing the energy flow card to show stale vehicles indefinitely.

## Changes
- **power-sync-energy-flow.js**: Added 15-min freshness check on `last_updated` in `isTruthyPresenceState()`, scoped to `binary_sensor.*` and `sensor.*` entities only. `person`/`device_tracker`/`input_boolean` entities are unaffected.

## Impact
Vehicles out of BLE range for 15+ min are treated as absent, allowing actually-present vehicles to render correctly.

## Note
This is a frontend-only change. No config flow or settings UI changes needed.