### PR TITLE
fix(frontend): strip raw BLE prefix from EV labels in energy flow card

### DIFF
--- a/custom_components/power_sync/frontend/power-sync-energy-flow.js
+++ b/custom_components/power_sync/frontend/power-sync-energy-flow.js
@@ -1111,7 +1111,21 @@
   }
 
   function friendlyEntityName(entityState) {
-    const name = String(entityState?.attributes?.friendly_name || '').trim();
+    let name = String(entityState?.attributes?.friendly_name || '').trim();
+    if (!name) return '';
+    // Clean up raw BLE prefixes for display:
+    //   "Tesla BLE (ble_slater)" → "Slater"
+    //   "Tesla BLE Slater Charge Level" → "Slater"
+    //   "ble_phoenix Power" → "Phoenix"
+    name = name
+      .replace(/^Tesla\s+BLE\s*/i, '')
+      .replace(/^\(?(ble_)/i, '')
+      .replace(/\)$/, '')
+      .replace(/\s*(charge\s*(level|flap|state)|power|battery|charger)\s*$/i, '')
+      .trim();
+    if (name.length > 0) {
+      name = name.charAt(0).toUpperCase() + name.slice(1);
+    }
     return name || '';
   }
 


### PR DESCRIPTION
## Summary
Energy flow card shows raw BLE entity names like "TESLA BLE (BLE_SLATER)" instead of clean vehicle names.

## Changes
- `friendlyEntityName()` strips common BLE prefixes, parentheses, and sensor suffixes
- Capitalizes remaining vehicle name

Examples: `Tesla BLE (ble_slater)` → `Slater`, `ble_phoenix Power` → `Phoenix`