### PR TITLE
fix(weather): skip unknown/unavailable weather entities

### DIFF
--- a/custom_components/power_sync/automations/weather.py
+++ b/custom_components/power_sync/automations/weather.py
@@ -107,7 +107,15 @@ def _weather_from_ha_entity(hass: HomeAssistant) -> Optional[Dict[str, Any]]:
     if not weather_entities:
         return None
 
-    state = weather_entities[0]
+    # Find the first weather entity with a valid state
+    state = None
+    for entity in weather_entities:
+        if entity.state not in (None, "unknown", "unavailable"):
+            state = entity
+            break
+    if state is None:
+        return None
+
     condition = _HA_WEATHER_TO_CONDITION.get(state.state, "partly_sunny")
     attrs = state.attributes or {}
     return {


### PR DESCRIPTION
## Summary

- Skip weather entities with state `unknown` or `unavailable` in HA weather resolver
- Return `None` (safe fallback) if no valid weather entity found
- Prevents string operation errors during HA startup or provider outages

**Files changed:** `automations/weather.py`

## Test plan

- [ ] All weather entities unavailable → returns None gracefully
- [ ] Mix of available/unavailable → uses first valid entity
- [ ] Normal behavior unchanged when entities healthy

Closes Artic0din/PowerSync#143

🤖 Generated with [Claude Code](https://claude.com/claude-code)