### PR TITLE
refactor(ev): pass per-vehicle minimum charging power to EVConfig

### DIFF
--- a/custom_components/power_sync/optimization/coordinator.py
+++ b/custom_components/power_sync/optimization/coordinator.py
@@ -4194,10 +4194,10 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entity_id: str,
         name: str | None = None,
         max_power_w: int = 7400,
-        min_power_w: int = 1400,
         target_soc: float = 0.8,
         departure_time: str | None = None,
         price_threshold: float | None = None,
+        min_power_w: int = 1400,
     ) -> bool:
         """Add an EV charger to smart charging coordination.
 
@@ -4205,14 +4205,21 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entity_id: HA entity ID of the EV charger
             name: Friendly name for the charger
             max_power_w: Maximum charging power in watts
-            min_power_w: Minimum charging power in watts (vehicle-specific)
             target_soc: Target state of charge (0-1)
             departure_time: Time when car needs to be ready (HH:MM)
             price_threshold: Max $/kWh for smart charging
+            min_power_w: Minimum charging power in watts (vehicle-specific)
 
         Returns:
             True if added successfully
         """
+        if min_power_w <= 0 or min_power_w > max_power_w:
+            _LOGGER.error(
+                "Invalid EV power bounds for %s: min_power_w=%s, max_power_w=%s",
+                entity_id, min_power_w, max_power_w,
+            )
+            return False
+
         config = EVConfig(
             entity_id=entity_id,
             name=name or entity_id.split(".")[-1],

--- a/custom_components/power_sync/optimization/coordinator.py
+++ b/custom_components/power_sync/optimization/coordinator.py
@@ -4194,6 +4194,7 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entity_id: str,
         name: str | None = None,
         max_power_w: int = 7400,
+        min_power_w: int = 1400,
         target_soc: float = 0.8,
         departure_time: str | None = None,
         price_threshold: float | None = None,
@@ -4204,6 +4205,7 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entity_id: HA entity ID of the EV charger
             name: Friendly name for the charger
             max_power_w: Maximum charging power in watts
+            min_power_w: Minimum charging power in watts (vehicle-specific)
             target_soc: Target state of charge (0-1)
             departure_time: Time when car needs to be ready (HH:MM)
             price_threshold: Max $/kWh for smart charging
@@ -4215,6 +4217,7 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entity_id=entity_id,
             name=name or entity_id.split(".")[-1],
             max_charging_power_w=max_power_w,
+            min_charging_power_w=min_power_w,
             target_soc=target_soc,
             departure_time=departure_time,
             price_threshold=price_threshold,


### PR DESCRIPTION
## Summary

- Add `min_power_w` parameter to `add_ev_charger()` (appended at end, backward compatible)
- Pass through to `EVConfig.min_charging_power_w` instead of always using hardcoded 1400W default
- Add validation: reject `min_power_w <= 0` or `> max_power_w`
- Enables per-vehicle minimum charging power configuration (different EVs have different thresholds)

**Files changed:** `optimization/coordinator.py`

## Test plan

- [ ] Existing `add_ev_charger()` calls work unchanged (default 1400W)
- [ ] Passing custom `min_power_w` propagates to EVConfig
- [ ] Invalid bounds (0, negative, > max) rejected with error log
- [ ] No behavioral change for existing users

Closes Artic0din/PowerSync#146

🤖 Generated with [Claude Code](https://claude.com/claude-code)