### PR TITLE
feat(update): add native HA update entity for version detection

### DIFF
--- a/custom_components/power_sync/__init__.py
+++ b/custom_components/power_sync/__init__.py
@@ -924,6 +924,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.NUMBER,
     Platform.BINARY_SENSOR,
+    Platform.UPDATE,
 ]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)

--- a/custom_components/power_sync/update.py
+++ b/custom_components/power_sync/update.py
@@ -1,0 +1,155 @@
+"""PowerSync Update Entity.
+
+Polls the GitHub Releases API to detect new versions and surfaces them
+through HA's native Updates panel (Settings → System → Updates).
+
+No authentication required — uses the public GitHub API.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from typing import Any
+
+import aiohttp
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+GITHUB_REPO = "bolagnaise/PowerSync"
+GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+SCAN_INTERVAL = timedelta(hours=1)
+
+
+def _installed_version() -> str:
+    """Read installed version from manifest.json."""
+    import json
+    from pathlib import Path
+
+    manifest_path = Path(__file__).parent / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        return manifest.get("version", "0.0.0")
+    except Exception:
+        return "0.0.0"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the PowerSync update entity."""
+    coordinator = PowerSyncUpdateCoordinator(hass)
+    await coordinator.async_config_entry_first_refresh()
+    async_add_entities([PowerSyncUpdateEntity(coordinator, entry)])
+
+
+class PowerSyncUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator that polls GitHub Releases API."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="PowerSync Update Check",
+            update_interval=SCAN_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch latest release from GitHub."""
+        session = async_get_clientsession(self.hass)
+        try:
+            async with session.get(
+                GITHUB_API_URL,
+                headers={"Accept": "application/vnd.github.v3+json"},
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status == 403:
+                    _LOGGER.debug("GitHub API rate limited, will retry next cycle")
+                    return self.data or {}
+                if resp.status != 200:
+                    raise UpdateFailed(f"GitHub API returned {resp.status}")
+                data = await resp.json()
+                tag = data.get("tag_name", "")
+                version = tag.lstrip("v")
+                return {
+                    "latest_version": version,
+                    "release_url": data.get("html_url", ""),
+                    "release_notes": data.get("body", ""),
+                    "published_at": data.get("published_at", ""),
+                }
+        except aiohttp.ClientError as err:
+            raise UpdateFailed(f"GitHub API request failed") from err
+
+
+class PowerSyncUpdateEntity(CoordinatorEntity, UpdateEntity):
+    """Update entity for PowerSync."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature.RELEASE_NOTES
+    _attr_has_entity_name = True
+    _attr_name = "Update"
+
+    def __init__(
+        self,
+        coordinator: PowerSyncUpdateCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the update entity."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_update"
+        self._installed = _installed_version()
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self._entry.entry_id)},
+            "name": "PowerSync",
+            "manufacturer": "PowerSync",
+        }
+
+    @property
+    def installed_version(self) -> str | None:
+        """Return the installed version."""
+        return self._installed
+
+    @property
+    def latest_version(self) -> str | None:
+        """Return the latest available version."""
+        if self.coordinator.data:
+            return self.coordinator.data.get("latest_version")
+        return self._installed
+
+    @property
+    def release_url(self) -> str | None:
+        """Return the release URL."""
+        if self.coordinator.data:
+            return self.coordinator.data.get("release_url")
+        return None
+
+    def release_notes(self) -> str | None:
+        """Return the release notes."""
+        if self.coordinator.data:
+            return self.coordinator.data.get("release_notes")
+        return None


### PR DESCRIPTION
## Summary

- Add `update.py` — native HA `UpdateEntity` that polls GitHub Releases API every hour
- Shows in **Settings → System → Updates** alongside core HA and HACS updates
- Uses HA shared `aiohttp` session, handles rate limiting gracefully
- Self-contained — only touch point is adding `Platform.UPDATE` to PLATFORMS list in `__init__.py`

## How it works

1. `PowerSyncUpdateCoordinator` polls `api.github.com/repos/bolagnaise/PowerSync/releases/latest` every hour
2. Compares latest release tag against installed version from `manifest.json`
3. If newer → entity state = `on`, appears in Updates panel with release notes + URL

## Files changed

- `custom_components/power_sync/update.py` (new)
- `custom_components/power_sync/__init__.py` (added `Platform.UPDATE` to PLATFORMS)

## Test plan

- [ ] Entity appears in Settings → System → Updates
- [ ] Shows "up to date" when on latest version
- [ ] Shows update available when newer release exists on GitHub
- [ ] Rate limiting handled (403 → skip cycle, retry next)
- [ ] Existing platforms unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)