### PR TITLE
fix(security): remove base_url override from cloud_probe view

### DIFF
--- a/custom_components/power_sync/powerwall_local/views.py
+++ b/custom_components/power_sync/powerwall_local/views.py
@@ -647,11 +647,7 @@ class PowerwallCloudProbeView(HomeAssistantView):
         path_suffix = str(payload.get("path", "island_mode"))
         method = str(payload.get("method", "POST")).upper()
         body = payload.get("body")
-        # Allow overriding the base URL to hit owner-api directly
-        override_base = payload.get("base_url")
-        effective_base = override_base or base
-
-        url = f"{effective_base}/api/1/energy_sites/{site_id}/{path_suffix}"
+        url = f"{base}/api/1/energy_sites/{site_id}/{path_suffix}"
         headers = {
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Removes `payload.get("base_url")` from `PowerwallCloudProbeView.post()`, preventing Tesla token exfiltration to attacker-controlled servers
- View now uses only the configured Tesla API base URL from config entry
- AEGIS finding: F-04-004 (CRITICAL)

## Test plan
- [ ] Verify PowerSync loads in HA without errors
- [ ] Verify cloud_probe calls still work with configured Tesla API base
- [ ] Verify POST body with `base_url` field is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)