### PR TITLE
Added voltx battery support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# PowerSync Copilot Instructions
+
+## Build, test, and validation
+
+- This repository does not define local `pytest`, lint, or package-manager script entry points.
+- CI validation is defined in `.github/workflows/validate.yml` and currently consists of:
+  - HACS validation via `hacs/action@main`
+  - Hassfest validation via `home-assistant/actions/hassfest@master`
+- There is no repo-defined single-test command because no automated test suite is checked in.
+- Releases are driven by version bumps in `custom_components/power_sync/manifest.json`; `.github/workflows/release.yml` watches that file.
+
+## High-level architecture
+
+- `custom_components/power_sync/__init__.py` is the integration hub. It owns config-entry setup/unload, chooses the active battery/provider path, stores runtime objects in `hass.data[DOMAIN][entry_id]`, registers services and HTTP views for the mobile app, and auto-registers the Lovelace frontend resources/dashboard.
+- `custom_components/power_sync/config_flow.py` is a large multi-step flow that branches first by electricity provider and then by battery system. Reauth is provider-specific too, especially for Tesla token sources.
+- `custom_components/power_sync/coordinator.py` contains the main update coordinators and persistence helpers such as the energy accumulator. Provider/battery adapters live in the top-level `*_api.py`, `inverters/`, and `powerwall_local/` modules.
+- `custom_components/power_sync/optimization/` is the built-in smart-optimization stack: forecast collection, LP optimization, EV coordination, and schedule execution.
+- `custom_components/power_sync/automations/` is a custom automation engine stored with Home Assistant `Store`; it is separate from native HA YAML/UI automations.
+- `custom_components/power_sync/frontend/` plus `HA Dashboard/README.md` define the generated PowerSync dashboard. The dashboard is strategy-based and renders sections by detecting which PowerSync entities exist, rather than relying on a static card layout.
+- `custom_components/power_sync/powerwall_local/` handles direct local Powerwall communication, including PW2 REST auth and PW3 pairing/signing flows.
+
+## Key conventions
+
+- Follow the integration's `entry.options.get(..., entry.data.get(...))` pattern. Mutable user settings usually live in `entry.options`; credentials and initial identifiers usually live in `entry.data`.
+- Runtime state is shared through `hass.data[DOMAIN][entry.entry_id]`. New coordinators, capability flags, automation stores, and dashboard-facing caches should be wired there consistently.
+- Entity identity is `entry.entry_id`-based. Unique IDs are typically `f"{entry.entry_id}_{key}"`, and entity IDs should prefer `power_sync_*` object IDs. Preserve the existing migration behavior for legacy unprefixed entity IDs instead of creating duplicates.
+- Dashboard/frontend changes are coupled to startup timing. `async_setup()` intentionally waits until Home Assistant has started before adding Lovelace resources or the auto-created dashboard; moving that earlier can wipe existing Lovelace resources.
+- The dashboard strategy supports both modern `power_sync_` entity prefixes and legacy bare names. Keep that backward-compatibility path intact when renaming entities.
+- If you add or rename a service, update both `custom_components/power_sync/services.yaml` and the imperative `hass.services.async_register(...)` calls in `custom_components/power_sync/__init__.py`.
+- `custom_components/power_sync/const.py` treats `manifest.json` as the version source of truth. `DASHBOARD_JS_VERSION` is a separate cache-busting switch for frontend resources.
+- Be careful with logs. `coordinator.py` includes a `SensitiveDataFilter` that masks tokens, site IDs, VINs, and similar identifiers; avoid adding raw sensitive values to new logs.
+- Release behavior spans multiple files: hand-written `RELEASE_NOTES.md` is preferred by `.github/workflows/release.yml`, and that workflow clears the file after publishing. Keep the workflow and release-note expectations aligned when changing release flow.

--- a/custom_components/power_sync/__init__.py
+++ b/custom_components/power_sync/__init__.py
@@ -240,6 +240,12 @@ from .const import (
     CONF_GOODWE_PROTOCOL,
     DEFAULT_GOODWE_PORT_UDP,
     DEFAULT_GOODWE_PORT_TCP,
+    # Voltx battery system configuration
+    CONF_VOLTX_HOST,
+    CONF_VOLTX_PORT,
+    CONF_VOLTX_SLAVE_ID,
+    DEFAULT_VOLTX_PORT,
+    DEFAULT_VOLTX_SLAVE_ID,
     # Octopus Energy UK configuration
     CONF_OCTOPUS_PRODUCT_CODE,
     CONF_OCTOPUS_TARIFF_CODE,
@@ -329,6 +335,7 @@ from .coordinator import (
     FoxESSEnergyCoordinator,
     GoodWeEnergyCoordinator,
     AlphaESSEnergyCoordinator,
+    VoltxEnergyCoordinator,
     DemandChargeCoordinator,
     AEMOSensorCoordinator,
     OctopusPriceCoordinator,
@@ -9430,6 +9437,7 @@ class SolarSurplusStatusView(HomeAssistantView):
             sigenergy_coordinator = entry_data.get("sigenergy_coordinator")
             sungrow_coordinator = entry_data.get("sungrow_coordinator")
             foxess_coordinator = entry_data.get("foxess_coordinator")
+            voltx_coordinator = entry_data.get("voltx_coordinator")
 
             if tesla_coordinator and tesla_coordinator.data:
                 # Tesla coordinator stores values in kW
@@ -9460,6 +9468,15 @@ class SolarSurplusStatusView(HomeAssistantView):
                 load_power_kw = foxess_coordinator.data.get("load_power", 0)
                 battery_soc = foxess_coordinator.data.get("battery_level", 0)
                 _LOGGER.debug(f"Solar surplus status from foxess_coordinator: battery_soc={battery_soc}%")
+            elif voltx_coordinator and voltx_coordinator.data:
+                # Voltx uses the same normalized coordinator payload as the
+                # other native batteries, so this shared view can consume it directly.
+                solar_power_kw = voltx_coordinator.data.get("solar_power", 0)
+                grid_power_kw = voltx_coordinator.data.get("grid_power", 0)
+                battery_power_kw = voltx_coordinator.data.get("battery_power", 0)
+                load_power_kw = voltx_coordinator.data.get("load_power", 0)
+                battery_soc = voltx_coordinator.data.get("battery_level", 0)
+                _LOGGER.debug(f"Solar surplus status from voltx_coordinator: battery_soc={battery_soc}%")
 
             # Calculate surplus
             live_status = {
@@ -10615,6 +10632,7 @@ class EVWidgetDataView(HomeAssistantView):
             sigenergy_coordinator = entry_data.get("sigenergy_coordinator")
             sungrow_coordinator = entry_data.get("sungrow_coordinator")
             foxess_coordinator = entry_data.get("foxess_coordinator")
+            voltx_coordinator = entry_data.get("voltx_coordinator")
 
             if tesla_coordinator and tesla_coordinator.data:
                 solar_power_kw = tesla_coordinator.data.get("solar_power", 0)
@@ -10640,6 +10658,14 @@ class EVWidgetDataView(HomeAssistantView):
                 battery_power_kw = foxess_coordinator.data.get("battery_power", 0)
                 load_power_kw = foxess_coordinator.data.get("load_power", 0)
                 battery_soc = foxess_coordinator.data.get("battery_level", 0)
+            elif voltx_coordinator and voltx_coordinator.data:
+                # Reuse the same normalized Voltx payload for the EV widget's
+                # live battery/solar snapshot.
+                solar_power_kw = voltx_coordinator.data.get("solar_power", 0)
+                grid_power_kw = voltx_coordinator.data.get("grid_power", 0)
+                battery_power_kw = voltx_coordinator.data.get("battery_power", 0)
+                load_power_kw = voltx_coordinator.data.get("load_power", 0)
+                battery_soc = voltx_coordinator.data.get("battery_level", 0)
 
             # Build live_status dict for surplus calculation (expects watts)
             live_status = {
@@ -11165,6 +11191,7 @@ class PriceRecommendationView(HomeAssistantView):
             sigenergy_coordinator = entry_data.get("sigenergy_coordinator")
             sungrow_coordinator = entry_data.get("sungrow_coordinator")
             foxess_coordinator = entry_data.get("foxess_coordinator")
+            voltx_coordinator = entry_data.get("voltx_coordinator")
 
             if tesla_coordinator and tesla_coordinator.data:
                 solar_power_kw = tesla_coordinator.data.get("solar_power", 0)
@@ -11190,6 +11217,14 @@ class PriceRecommendationView(HomeAssistantView):
                 battery_power_kw = foxess_coordinator.data.get("battery_power", 0)
                 load_power_kw = foxess_coordinator.data.get("load_power", 0)
                 battery_soc = foxess_coordinator.data.get("battery_level", 0)
+            elif voltx_coordinator and voltx_coordinator.data:
+                # Reuse the same normalized Voltx payload for price guidance and
+                # surplus calculations shown in the mobile/web UI.
+                solar_power_kw = voltx_coordinator.data.get("solar_power", 0)
+                grid_power_kw = voltx_coordinator.data.get("grid_power", 0)
+                battery_power_kw = voltx_coordinator.data.get("battery_power", 0)
+                load_power_kw = voltx_coordinator.data.get("load_power", 0)
+                battery_soc = voltx_coordinator.data.get("battery_level", 0)
 
             # Build live_status dict for surplus calculation (expects watts)
             live_status = {
@@ -12512,12 +12547,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning("Failed to start Amber usage coordinator: %s", e)
             amber_usage_coordinator = None
 
-    # Check if this is a Sigenergy, Sungrow, FoxESS, GoodWe, or AlphaESS setup (no Tesla needed)
+    # Check if this is a non-Tesla battery system setup (no Tesla needed)
     is_sigenergy = bool(entry.data.get(CONF_SIGENERGY_STATION_ID))
     is_sungrow = bool(entry.data.get(CONF_SUNGROW_HOST))
     is_foxess = bool(entry.data.get(CONF_FOXESS_HOST) or entry.data.get(CONF_FOXESS_SERIAL_PORT))
     is_goodwe = bool(entry.data.get(CONF_GOODWE_HOST))
     is_alphaess = bool(entry.data.get(CONF_ALPHAESS_MODBUS_HOST))
+    is_voltx = bool(entry.data.get(CONF_VOLTX_HOST))
     tesla_coordinator = None
     sigenergy_coordinator = None
     sungrow_coordinator = None
@@ -12525,6 +12561,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     foxess_coordinator = None
     goodwe_coordinator = None
     alphaess_coordinator = None
+    voltx_coordinator = None
     token_getter = None  # Will be set for Tesla users
 
     if is_sigenergy:
@@ -12698,6 +12735,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             max_export_limit_kw=alphaess_export_limit_kw,
             cloud_client=alphaess_cloud_client,
         )
+    elif is_voltx:
+        _LOGGER.info("Running in Voltx mode - Tesla credentials not required")
+
+        # Voltx is a native non-Tesla path: setup only needs the stored Modbus
+        # endpoint so the runtime can bootstrap the energy coordinator.
+        voltx_host = entry.options.get(CONF_VOLTX_HOST, entry.data.get(CONF_VOLTX_HOST))
+        voltx_port = entry.options.get(
+            CONF_VOLTX_PORT,
+            entry.data.get(CONF_VOLTX_PORT, DEFAULT_VOLTX_PORT),
+        )
+        voltx_slave_id = entry.options.get(
+            CONF_VOLTX_SLAVE_ID,
+            entry.data.get(CONF_VOLTX_SLAVE_ID, DEFAULT_VOLTX_SLAVE_ID),
+        )
+
+        _LOGGER.info(
+            "Initializing Voltx Modbus coordinator: %s:%s (slave %s)",
+            voltx_host, voltx_port, voltx_slave_id,
+        )
+        voltx_coordinator = VoltxEnergyCoordinator(
+            hass,
+            voltx_host,
+            port=int(voltx_port),
+            slave_id=int(voltx_slave_id),
+            entry_id=entry.entry_id,
+        )
     else:
         # Get initial Tesla API token and provider
         # Use get_tesla_api_token() which fetches fresh from tesla_fleet if available
@@ -12799,6 +12862,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception as e:
             _LOGGER.warning("AlphaESS coordinator failed to initialize: %s", e)
             alphaess_coordinator = None
+    if voltx_coordinator:
+        try:
+            # Probe the inverter during setup so we surface missing telemetry
+            # early instead of deferring the failure until entities start polling.
+            await voltx_coordinator.async_config_entry_first_refresh()
+            _LOGGER.info("Voltx coordinator initialized successfully")
+        except Exception as e:
+            _LOGGER.warning("Voltx coordinator failed to initialize: %s", e)
+            voltx_coordinator = None
 
     # Initialize demand charge coordinator if enabled (any battery system with grid power data)
     demand_charge_coordinator = None
@@ -12868,7 +12940,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     # Tesla AEMO Spike Manager (tariff-based) — only for Tesla
-    if aemo_spike_enabled and has_tesla_site and not is_sigenergy and not is_sungrow and not is_foxess and not is_goodwe:
+    if aemo_spike_enabled and has_tesla_site and not is_sigenergy and not is_sungrow and not is_foxess and not is_goodwe and not is_voltx:
         aemo_region = entry.options.get(
             CONF_AEMO_REGION,
             entry.data.get(CONF_AEMO_REGION)
@@ -12898,7 +12970,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning("AEMO spike detection enabled but no region configured")
 
     # Generic AEMO Spike Manager (service-call-based) for non-Tesla systems
-    if aemo_spike_enabled and (is_sigenergy or is_sungrow or is_foxess):
+    if aemo_spike_enabled and (is_sigenergy or is_sungrow or is_foxess or is_goodwe or is_voltx):
         aemo_region = entry.options.get(
             CONF_AEMO_REGION,
             entry.data.get(CONF_AEMO_REGION)
@@ -12909,7 +12981,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
         if aemo_region:
-            battery_type = "sigenergy" if is_sigenergy else "sungrow" if is_sungrow else "goodwe" if is_goodwe else "foxess"
+            # Voltx fits the existing non-Tesla service-call manager model, so
+            # it can participate without a Tesla-specific tariff implementation.
+            battery_type = (
+                "sigenergy"
+                if is_sigenergy
+                else "sungrow"
+                if is_sungrow
+                else "goodwe"
+                if is_goodwe
+                else "voltx"
+                if is_voltx
+                else "foxess"
+            )
             generic_aemo_spike_manager = GenericAEMOSpikeManager(
                 hass=hass,
                 entry=entry,
@@ -13005,7 +13089,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Create session managers for non-LP battery control
         if saving_session_coordinator:
             # Tesla TOU mode manager
-            if has_tesla_site and not is_sigenergy and not is_sungrow and not is_foxess and not is_goodwe:
+            if has_tesla_site and not is_sigenergy and not is_sungrow and not is_foxess and not is_goodwe and not is_voltx:
                 saving_session_tariff_manager = SavingSessionTariffManager(
                     hass=hass,
                     entry=entry,
@@ -13019,8 +13103,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.info("Saving Session Tariff Manager initialized for Tesla")
 
             # Non-Tesla generic manager
-            elif is_sigenergy or is_sungrow or is_foxess or is_goodwe:
-                battery_type = "sigenergy" if is_sigenergy else "sungrow" if is_sungrow else "goodwe" if is_goodwe else "foxess"
+            elif is_sigenergy or is_sungrow or is_foxess or is_goodwe or is_voltx:
+                # Voltx reuses the same generic saving-session service routing
+                # as the other native non-Tesla battery integrations.
+                battery_type = (
+                    "sigenergy"
+                    if is_sigenergy
+                    else "sungrow"
+                    if is_sungrow
+                    else "goodwe"
+                    if is_goodwe
+                    else "voltx"
+                    if is_voltx
+                    else "foxess"
+                )
                 generic_saving_session_manager = GenericSavingSessionManager(
                     hass=hass,
                     entry=entry,
@@ -13339,6 +13435,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "foxess_coordinator": foxess_coordinator,  # For FoxESS Modbus energy/battery data
         "goodwe_coordinator": goodwe_coordinator,  # For GoodWe energy/battery data
         "alphaess_coordinator": alphaess_coordinator,  # For AlphaESS Modbus + cloud fallback
+        "voltx_coordinator": voltx_coordinator,  # For Voltx Modbus energy/battery data
         "demand_charge_coordinator": demand_charge_coordinator,
         "aemo_spike_manager": aemo_spike_manager,
         "generic_aemo_spike_manager": generic_aemo_spike_manager,  # For non-Tesla AEMO spike detection
@@ -13369,6 +13466,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "is_foxess": is_foxess,  # Track if FoxESS battery system
         "is_goodwe": is_goodwe,  # Track if GoodWe battery system
         "is_alphaess": is_alphaess,  # Track if AlphaESS battery system
+        "is_voltx": is_voltx,  # Track if Voltx battery system
         "foxess_curtailment_state": "normal",  # Track FoxESS DC curtailment state
         "sigenergy_curtailment_state": "normal",  # Track Sigenergy DC curtailment state
         "alphaess_curtailment_state": "normal",  # Track AlphaESS DC curtailment state
@@ -16132,6 +16230,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await handle_alphaess_curtailment()
             return
 
+        if is_voltx:
+            # The Voltx Modbus TCP registers used here do not expose full site
+            # CT telemetry, so PowerSync cannot safely run curtailment logic.
+            _LOGGER.debug("Solar curtailment is not implemented for Voltx battery systems")
+            return
+
         # Find an available price coordinator (Amber, AEMO, or Octopus)
         _price_coord = amber_coordinator or localvolts_coordinator or aemo_sensor_coordinator or octopus_coordinator
         if not _price_coord:
@@ -16469,6 +16573,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             feedin_price = websocket_data.get('feedIn', {}).get('perKwh') if websocket_data else None
             import_price = websocket_data.get('general', {}).get('perKwh') if websocket_data else None
             await handle_alphaess_curtailment(feedin_price=feedin_price, import_price=import_price)
+            return
+
+        if is_voltx:
+            # Same limitation as the polling path above: no site CT telemetry is
+            # available here for a safe Voltx curtailment decision.
+            _LOGGER.debug("WebSocket solar curtailment is not implemented for Voltx battery systems")
             return
 
         _LOGGER.info("=== Starting solar curtailment check (WebSocket event-driven) ===")
@@ -17095,6 +17205,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await alphaess_coord.force_discharge(duration, power_w=power_w)
                 _LOGGER.debug(f"AlphaESS force discharge hardware extended ({duration}min, {power_w}W)")
                 return
+            voltx_coord = entry_data.get("voltx_coordinator")
+            if voltx_coord:
+                # Optimizer refreshes and manual "extend hardware" calls reuse
+                # the native Voltx write path without touching UI timer state.
+                await voltx_coord.force_discharge(duration, power_w=power_w)
+                _LOGGER.debug(f"Voltx force discharge hardware extended ({duration}min, {power_w}W)")
+                return
             _LOGGER.warning("_extend_hardware: no coordinator found, falling through to full handler")
 
         _LOGGER.info(f"🔋 FORCE DISCHARGE: Activating for {duration} minutes (source={source})")
@@ -17382,6 +17499,61 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 force_discharge_state["active"] = False
                 _LOGGER.error(f"Error in AlphaESS force discharge: {e}", exc_info=True)
                 hass.async_create_task(_notify_api_error(hass, "Force Discharge Failed", "AlphaESS Modbus communication error"))
+                return
+
+        # Check if this is a Voltx system
+        is_voltx = bool(entry.data.get(CONF_VOLTX_HOST))
+        if is_voltx:
+            try:
+                entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+                voltx_coord = entry_data.get("voltx_coordinator")
+                if not voltx_coord:
+                    force_discharge_state["active"] = False
+                    _LOGGER.error("Force discharge: Voltx coordinator not available")
+                    return
+
+                # Reuse the shared PowerSync timer/state machinery while sending
+                # the actual force-discharge command through native Voltx Modbus.
+                power_w = call.data.get("power_w", 0)
+                discharge_result = await voltx_coord.force_discharge(duration, power_w=power_w)
+
+                if discharge_result:
+                    force_discharge_state["active"] = True
+                    force_discharge_state["source"] = source
+                    force_discharge_state["expires_at"] = dt_util.utcnow() + timedelta(minutes=duration)
+                    _LOGGER.info(f"Voltx FORCE DISCHARGE ACTIVE for {duration} minutes (power_w={power_w})")
+
+                    async_dispatcher_send(hass, f"{DOMAIN}_force_discharge_state", {
+                        "active": True,
+                        "expires_at": force_discharge_state["expires_at"].isoformat(),
+                        "duration": duration,
+                    })
+
+                    if force_discharge_state.get("cancel_expiry_timer"):
+                        force_discharge_state["cancel_expiry_timer"]()
+
+                    async def auto_restore_discharge_voltx(_now):
+                        if _command_generation[0] != _restore_gen:
+                            _LOGGER.debug("Voltx force discharge timer superseded — skipping restore")
+                            return
+                        if force_discharge_state["active"]:
+                            _LOGGER.info("Voltx force discharge expired, auto-restoring")
+                            await hass.services.async_call(DOMAIN, SERVICE_RESTORE_NORMAL, {}, blocking=True)
+
+                    force_discharge_state["cancel_expiry_timer"] = async_track_point_in_utc_time(
+                        hass,
+                        auto_restore_discharge_voltx,
+                        force_discharge_state["expires_at"],
+                    )
+                    await persist_force_mode_state()
+                else:
+                    force_discharge_state["active"] = False
+                    _LOGGER.error("Voltx force discharge failed")
+                return
+            except Exception as e:
+                force_discharge_state["active"] = False
+                _LOGGER.error(f"Error in Voltx force discharge: {e}", exc_info=True)
+                hass.async_create_task(_notify_api_error(hass, "Force Discharge Failed", "Voltx Modbus communication error"))
                 return
 
         # Check if this is a Sungrow system
@@ -17914,6 +18086,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 await alphaess_coord.force_charge(duration, power_w=power_w)
                 _LOGGER.debug(f"AlphaESS force charge hardware extended ({duration}min, {power_w}W)")
                 return
+            voltx_coord = entry_data.get("voltx_coordinator")
+            if voltx_coord:
+                await voltx_coord.force_charge(duration, power_w=power_w)
+                _LOGGER.debug(f"Voltx force charge hardware extended ({duration}min, {power_w}W)")
+                return
             # Fallback: no coordinator found, proceed with full handler
             _LOGGER.warning("_extend_hardware: no coordinator found, falling through to full handler")
 
@@ -18241,6 +18418,69 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 force_charge_state["active"] = False
                 _LOGGER.error(f"Error in AlphaESS force charge: {e}", exc_info=True)
                 hass.async_create_task(_notify_api_error(hass, "Force Charge Failed", "AlphaESS Modbus communication error"))
+                return
+
+        # Check if this is a Voltx system
+        is_voltx = bool(entry.data.get(CONF_VOLTX_HOST))
+        if is_voltx:
+            try:
+                entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+                voltx_coord = entry_data.get("voltx_coordinator")
+                if not voltx_coord:
+                    force_charge_state["active"] = False
+                    _LOGGER.error("Force charge: Voltx coordinator not available")
+                    return
+
+                if force_discharge_state["active"]:
+                    _LOGGER.info("Canceling active discharge mode to enable charge mode")
+                    if force_discharge_state.get("cancel_expiry_timer"):
+                        force_discharge_state["cancel_expiry_timer"]()
+                        force_discharge_state["cancel_expiry_timer"] = None
+                    force_discharge_state["active"] = False
+                    force_discharge_state["expires_at"] = None
+
+                # PowerSync owns the duration countdown; the coordinator only
+                # needs the immediate "force charge now" Modbus write.
+                power_w = call.data.get("power_w", 0)
+                charge_result = await voltx_coord.force_charge(duration, power_w=power_w)
+
+                if charge_result:
+                    force_charge_state["active"] = True
+                    force_charge_state["source"] = source
+                    force_charge_state["expires_at"] = dt_util.utcnow() + timedelta(minutes=duration)
+                    _LOGGER.info(f"Voltx FORCE CHARGE ACTIVE for {duration} minutes (power_w={power_w})")
+
+                    async_dispatcher_send(hass, f"{DOMAIN}_force_charge_state", {
+                        "active": True,
+                        "expires_at": force_charge_state["expires_at"].isoformat(),
+                        "duration": duration,
+                    })
+
+                    if force_charge_state.get("cancel_expiry_timer"):
+                        force_charge_state["cancel_expiry_timer"]()
+
+                    async def auto_restore_charge_voltx(_now):
+                        if _command_generation[0] != _restore_gen:
+                            _LOGGER.debug("Voltx force charge timer superseded — skipping restore")
+                            return
+                        if force_charge_state["active"]:
+                            _LOGGER.info("Voltx force charge expired, auto-restoring")
+                            await hass.services.async_call(DOMAIN, SERVICE_RESTORE_NORMAL, {}, blocking=True)
+
+                    force_charge_state["cancel_expiry_timer"] = async_track_point_in_utc_time(
+                        hass,
+                        auto_restore_charge_voltx,
+                        force_charge_state["expires_at"],
+                    )
+                    await persist_force_mode_state()
+                else:
+                    force_charge_state["active"] = False
+                    _LOGGER.error("Voltx force charge failed")
+                return
+            except Exception as e:
+                force_charge_state["active"] = False
+                _LOGGER.error(f"Error in Voltx force charge: {e}", exc_info=True)
+                hass.async_create_task(_notify_api_error(hass, "Force Charge Failed", "Voltx Modbus communication error"))
                 return
 
         # Check if this is a Sungrow system
@@ -18954,6 +19194,44 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.error(f"Error in AlphaESS restore normal: {e}", exc_info=True)
                 return
 
+        # Check if this is a Voltx system
+        is_voltx = bool(entry.data.get(CONF_VOLTX_HOST))
+        if is_voltx:
+            try:
+                entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+                voltx_coord = entry_data.get("voltx_coordinator")
+                if voltx_coord:
+                    # restore_normal maps back to Voltx self-consumption mode
+                    # and clears any custom charge/discharge command.
+                    await voltx_coord.restore_normal()
+
+                force_charge_state["active"] = False
+                force_discharge_state["active"] = False
+                force_charge_state["expires_at"] = None
+                force_discharge_state["expires_at"] = None
+
+                _LOGGER.info("Voltx NORMAL OPERATION RESTORED")
+
+                if not suppress_notification:
+                    try:
+                        from .automations.actions import _send_expo_push
+                        await _send_expo_push(hass, "Battery", "Normal operation restored")
+                    except Exception as notify_err:
+                        _LOGGER.debug(f"Could not send success notification: {notify_err}")
+
+                async_dispatcher_send(hass, f"{DOMAIN}_force_discharge_state", {
+                    "active": False, "expires_at": None, "duration": 0,
+                })
+                async_dispatcher_send(hass, f"{DOMAIN}_force_charge_state", {
+                    "active": False, "expires_at": None, "duration": 0,
+                })
+
+                await persist_force_mode_state()
+                return
+            except Exception as e:
+                _LOGGER.error(f"Error in Voltx restore normal: {e}", exc_info=True)
+                return
+
         # Check if this is a Sungrow system
         is_sungrow = bool(entry.data.get(CONF_SUNGROW_HOST))
         if is_sungrow:
@@ -19593,6 +19871,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.error(f"Error setting AlphaESS self-consumption: {e}", exc_info=True)
                 return
 
+        # Check if this is a Voltx system
+        is_voltx = bool(entry.data.get(CONF_VOLTX_HOST))
+        if is_voltx:
+            try:
+                entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+                voltx_coord = entry_data.get("voltx_coordinator")
+                if voltx_coord and hasattr(voltx_coord, '_controller') and voltx_coord._controller:
+                    # The generic self-consumption service maps directly to the
+                    # same Voltx register write used by restore_normal.
+                    controller = voltx_coord._controller
+                    result = await controller.set_self_consumption_mode()
+                    if result:
+                        _LOGGER.info("Voltx self-consumption mode set")
+                    else:
+                        _LOGGER.warning("Voltx set_self_consumption_mode failed")
+                else:
+                    _LOGGER.error("Self-consumption: Voltx coordinator/controller not available")
+                return
+            except Exception as e:
+                _LOGGER.error(f"Error setting Voltx self-consumption: {e}", exc_info=True)
+                return
+
         # Tesla Powerwall
         try:
             site_configs = _get_tesla_site_configs(hass, entry)
@@ -19643,7 +19943,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         is_sigenergy = bool(entry.data.get(CONF_SIGENERGY_STATION_ID))
         is_goodwe = bool(entry.data.get(CONF_GOODWE_HOST))
         is_alphaess = bool(entry.data.get(CONF_ALPHAESS_MODBUS_HOST))
-        if is_foxess or is_sungrow or is_sigenergy or is_goodwe or is_alphaess:
+        is_voltx = bool(entry.data.get(CONF_VOLTX_HOST))
+        if is_foxess or is_sungrow or is_sigenergy or is_goodwe or is_alphaess or is_voltx:
             _LOGGER.debug("Non-Tesla system — autonomous mode is implicit, skipping")
             return
 
@@ -19711,6 +20012,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         is_sungrow = bool(entry.data.get(CONF_SUNGROW_HOST))
         # Check if this is a GoodWe system
         is_goodwe = bool(entry.data.get(CONF_GOODWE_HOST))
+        # Check if this is a Voltx system
+        is_voltx = bool(entry.data.get(CONF_VOLTX_HOST))
 
         if is_goodwe:
             # GoodWe via goodwe library (DOD)
@@ -19803,6 +20106,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
             except Exception as e:
                 _LOGGER.error(f"Error setting SigEnergy backup reserve: {e}", exc_info=True)
+        elif is_voltx:
+            try:
+                entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+                voltx_coord = entry_data.get("voltx_coordinator")
+                if not voltx_coord:
+                    _LOGGER.error("Voltx coordinator not available for set_backup_reserve")
+                    return
+
+                # Voltx reserve writes map directly to soc_min, so the shared
+                # backup-reserve service can call the coordinator wrapper.
+                success = await voltx_coord.set_backup_reserve(percent)
+                if success:
+                    _LOGGER.info(f"✅ Voltx backup reserve set to {percent}%")
+                else:
+                    _LOGGER.error("Failed to set Voltx backup reserve")
+            except Exception as e:
+                _LOGGER.error(f"Error setting Voltx backup reserve: {e}", exc_info=True)
         else:
             # Tesla Powerwall via Fleet API
             try:
@@ -22626,7 +22946,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Flush energy accumulator so the next restore has the latest values
     # (prevents total_increasing sensors from going backwards after reload)
     for coord_key in ("tesla_coordinator", "sigenergy_coordinator", "sungrow_coordinator",
-                      "foxess_coordinator", "goodwe_coordinator"):
+                      "foxess_coordinator", "goodwe_coordinator", "alphaess_coordinator",
+                      "voltx_coordinator"):
         coord = entry_data.get(coord_key)
         if coord and hasattr(coord, "_energy_acc"):
             try:

--- a/custom_components/power_sync/config_flow.py
+++ b/custom_components/power_sync/config_flow.py
@@ -72,6 +72,7 @@ from .const import (
     BATTERY_SYSTEM_SUNGROW,
     BATTERY_SYSTEM_FOXESS,
     BATTERY_SYSTEM_ALPHAESS,
+    BATTERY_SYSTEM_VOLTX,
     BATTERY_SYSTEMS,
     # AlphaESS battery system configuration
     CONF_ALPHAESS_MODBUS_HOST,
@@ -321,6 +322,12 @@ from .const import (
     DEFAULT_GOODWE_PORT_UDP,
     DEFAULT_GOODWE_PORT_TCP,
     BATTERY_SYSTEM_GOODWE,
+    # Voltx battery system configuration
+    CONF_VOLTX_HOST,
+    CONF_VOLTX_PORT,
+    CONF_VOLTX_SLAVE_ID,
+    DEFAULT_VOLTX_PORT,
+    DEFAULT_VOLTX_SLAVE_ID,
     # NZ Electricity provider configuration
     CONF_NZ_RETAILER,
     CONF_NZ_DISTRIBUTION_ZONE,
@@ -742,6 +749,7 @@ class PowerSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._sungrow_data: dict[str, Any] = {}  # Sungrow Modbus configuration
         self._foxess_data: dict[str, Any] = {}  # FoxESS Modbus configuration
         self._goodwe_data: dict[str, Any] = {}  # GoodWe configuration
+        self._voltx_data: dict[str, Any] = {}  # Voltx Modbus configuration
         self._aemo_only_mode: bool = False  # True if using AEMO spike only (no Amber)
         self._aemo_data: dict[str, Any] = {}
         self._flow_power_data: dict[str, Any] = {}
@@ -1038,6 +1046,10 @@ class PowerSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_goodwe_connection()
         elif self._selected_battery_system == BATTERY_SYSTEM_ALPHAESS:
             return await self.async_step_alphaess_modbus()
+        elif self._selected_battery_system == BATTERY_SYSTEM_VOLTX:
+            # Voltx has a native battery setup step, separate from the generic
+            # AC inverter curtailment brand selector used elsewhere in the flow.
+            return await self.async_step_voltx_connection()
         else:
             return await self.async_step_tesla_provider()
 
@@ -1062,6 +1074,9 @@ class PowerSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             **getattr(self, "_foxess_data", {}),
             **getattr(self, "_goodwe_data", {}),
             **getattr(self, "_alphaess_data", {}),
+            # Keep the validated Voltx endpoint details on the config entry so
+            # runtime setup can recreate the native Modbus coordinator directly.
+            **getattr(self, "_voltx_data", {}),
             CONF_ELECTRICITY_PROVIDER: self._selected_electricity_provider,
         }
 
@@ -1099,6 +1114,7 @@ class PowerSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             BATTERY_SYSTEM_FOXESS: "FoxESS",
             BATTERY_SYSTEM_GOODWE: "GoodWe",
             BATTERY_SYSTEM_ALPHAESS: "AlphaESS",
+            BATTERY_SYSTEM_VOLTX: "Voltx",
         }.get(self._selected_battery_system, "")
 
         if battery_label:
@@ -1874,6 +1890,79 @@ class PowerSyncConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "Leave blank to skip."
                 ),
             },
+        )
+
+    async def async_step_voltx_connection(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure Voltx / Solplanet Modbus TCP connection."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input.get(CONF_VOLTX_HOST, "").strip()
+            port = user_input.get(CONF_VOLTX_PORT, DEFAULT_VOLTX_PORT)
+            slave_id = user_input.get(CONF_VOLTX_SLAVE_ID, DEFAULT_VOLTX_SLAVE_ID)
+
+            if not host:
+                errors["base"] = "voltx_host_required"
+            else:
+                from .inverters.voltx import VoltxController
+
+                # Validate with the same controller class used at runtime so the
+                # setup flow and the live integration share one register contract.
+                controller = VoltxController(
+                    host=host,
+                    port=int(port),
+                    slave_id=int(slave_id),
+                )
+                try:
+                    connected = await controller.connect()
+                    if not connected:
+                        errors["base"] = "voltx_connection_failed"
+                    else:
+                        state = await controller.get_status()
+                        if state.attributes is None or "battery_soc" not in state.attributes:
+                            errors["base"] = "voltx_no_data"
+                finally:
+                    try:
+                        await controller.disconnect()
+                    except Exception:
+                        pass
+
+                if not errors:
+                    self._voltx_data = {
+                        CONF_VOLTX_HOST: host,
+                        CONF_VOLTX_PORT: int(port),
+                        CONF_VOLTX_SLAVE_ID: int(slave_id),
+                    }
+                    return self._create_final_entry()
+
+        return self.async_show_form(
+            step_id="voltx_connection",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_VOLTX_HOST): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.TEXT)
+                    ),
+                    vol.Optional(
+                        CONF_VOLTX_PORT,
+                        default=DEFAULT_VOLTX_PORT,
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=1, max=65535, step=1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_VOLTX_SLAVE_ID,
+                        default=DEFAULT_VOLTX_SLAVE_ID,
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=1, max=247, step=1, mode=NumberSelectorMode.BOX
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
         )
 
     async def async_step_sungrow(
@@ -3142,6 +3231,10 @@ class PowerSyncOptionsFlow(config_entries.OptionsFlow):
             menu_options.append("foxess_connection_options")
         elif battery_system == BATTERY_SYSTEM_GOODWE:
             menu_options.append("goodwe_connection_options")
+        elif battery_system == BATTERY_SYSTEM_VOLTX:
+            # Offer Voltx endpoint editing in options without forcing users to
+            # remove and recreate the integration entry.
+            menu_options.append("voltx_connection_options")
 
         menu_options.extend([
             "optimization",
@@ -3748,6 +3841,65 @@ class PowerSyncOptionsFlow(config_entries.OptionsFlow):
             errors=errors,
         )
 
+    async def async_step_voltx_connection_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Menu handler: Voltx Modbus connection settings."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input.get(CONF_VOLTX_HOST, "").strip()
+            if not host:
+                errors["base"] = "voltx_host_required"
+            else:
+                # Only the stored connection parameters change here; the reload
+                # path rebuilds the Voltx coordinator with the new endpoint.
+                new_data = dict(self.config_entry.data)
+                new_data[CONF_VOLTX_HOST] = host
+                new_data[CONF_VOLTX_PORT] = user_input.get(
+                    CONF_VOLTX_PORT, DEFAULT_VOLTX_PORT
+                )
+                new_data[CONF_VOLTX_SLAVE_ID] = user_input.get(
+                    CONF_VOLTX_SLAVE_ID, DEFAULT_VOLTX_SLAVE_ID
+                )
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry, data=new_data
+                )
+                return self.async_create_entry(
+                    title="", data=dict(self.config_entry.options)
+                )
+
+        current_host = self._get_option(CONF_VOLTX_HOST, "")
+        current_port = self._get_option(CONF_VOLTX_PORT, DEFAULT_VOLTX_PORT)
+        current_slave_id = self._get_option(
+            CONF_VOLTX_SLAVE_ID, DEFAULT_VOLTX_SLAVE_ID
+        )
+
+        return self.async_show_form(
+            step_id="voltx_connection_options",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_VOLTX_HOST,
+                        default=current_host,
+                    ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
+                    vol.Optional(
+                        CONF_VOLTX_PORT,
+                        default=current_port,
+                    ): NumberSelector(NumberSelectorConfig(
+                        min=1, max=65535, step=1, mode=NumberSelectorMode.BOX,
+                    )),
+                    vol.Optional(
+                        CONF_VOLTX_SLAVE_ID,
+                        default=current_slave_id,
+                    ): NumberSelector(NumberSelectorConfig(
+                        min=1, max=247, step=1, mode=NumberSelectorMode.BOX,
+                    )),
+                }
+            ),
+            errors=errors,
+        )
+
     async def async_step_optimization(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -3792,6 +3944,9 @@ class PowerSyncOptionsFlow(config_entries.OptionsFlow):
             BATTERY_SYSTEM_SUNGROW: "Sungrow built-in optimization",
             BATTERY_SYSTEM_FOXESS: "FoxESS built-in optimization",
             BATTERY_SYSTEM_GOODWE: "GoodWe built-in optimization",
+            # Voltx reuses the existing native/manual-control behavior, so it
+            # fits the same "built-in optimization" label as other batteries.
+            BATTERY_SYSTEM_VOLTX: "Voltx built-in optimization",
         }
         native_label = native_labels.get(battery_system, "Built-in optimization")
 

--- a/custom_components/power_sync/const.py
+++ b/custom_components/power_sync/const.py
@@ -127,6 +127,9 @@ BATTERY_SYSTEM_SUNGROW = "sungrow"
 BATTERY_SYSTEM_FOXESS = "foxess"
 BATTERY_SYSTEM_GOODWE = "goodwe"
 BATTERY_SYSTEM_ALPHAESS = "alphaess"
+# Voltx is treated as a first-class battery system so it shows up in the
+# main setup flow and participates in the generic battery service routing.
+BATTERY_SYSTEM_VOLTX = "voltx"
 
 BATTERY_SYSTEMS = {
     BATTERY_SYSTEM_TESLA: "Tesla Powerwall — Fleet API or Teslemetry",
@@ -135,7 +138,17 @@ BATTERY_SYSTEMS = {
     BATTERY_SYSTEM_FOXESS: "FoxESS — Modbus TCP or RS485 serial",
     BATTERY_SYSTEM_GOODWE: "GoodWe ET/EH/ES/EM — UDP or TCP",
     BATTERY_SYSTEM_ALPHAESS: "AlphaESS SMILE/Storion — Modbus TCP + optional Cloud API",
+    BATTERY_SYSTEM_VOLTX: "Voltx / Solplanet hybrid — Modbus TCP",
 }
+
+# Voltx / Solplanet Battery System Configuration (Modbus TCP)
+# Defaults mirror the proof-of-concept integration and the observed inverter
+# Monitor-port Modbus settings used during development.
+CONF_VOLTX_HOST = "voltx_host"
+CONF_VOLTX_PORT = "voltx_port"
+CONF_VOLTX_SLAVE_ID = "voltx_slave_id"
+DEFAULT_VOLTX_PORT = 502
+DEFAULT_VOLTX_SLAVE_ID = 3
 
 # Sungrow SH-series Battery System Configuration (Modbus TCP)
 # Hybrid inverters with integrated battery control
@@ -1419,6 +1432,7 @@ OPTIMIZATION_PROVIDER_NATIVE_NAMES = {
     BATTERY_SYSTEM_FOXESS: "FoxESS",
     BATTERY_SYSTEM_GOODWE: "GoodWe",
     BATTERY_SYSTEM_ALPHAESS: "AlphaESS",
+    BATTERY_SYSTEM_VOLTX: "Voltx",
 }
 
 OPTIMIZATION_PROVIDERS = {
@@ -1458,6 +1472,7 @@ BATTERY_CAPACITY_DEFAULTS = {
     BATTERY_SYSTEM_FOXESS: 10000,     # Varies, default 10 kWh
     BATTERY_SYSTEM_GOODWE: 10000,     # Varies, default 10 kWh
     BATTERY_SYSTEM_ALPHAESS: 10000,   # Varies (SMILE5 ~ 5.7 kWh, Storion ~ 30 kWh), default 10 kWh
+    BATTERY_SYSTEM_VOLTX: 10000,      # Varies, default 10 kWh
 }
 
 # Max charge/discharge power defaults by system (W)
@@ -1468,6 +1483,7 @@ BATTERY_POWER_DEFAULTS = {
     BATTERY_SYSTEM_FOXESS: 5000,      # Varies by model
     BATTERY_SYSTEM_GOODWE: 5000,      # Varies by model
     BATTERY_SYSTEM_ALPHAESS: 5000,    # Varies by model (SMILE5 = 5 kW, Storion-T30 larger)
+    BATTERY_SYSTEM_VOLTX: 5000,       # Varies by inverter/battery pairing
 }
 
 # Optimization service

--- a/custom_components/power_sync/coordinator.py
+++ b/custom_components/power_sync/coordinator.py
@@ -3440,6 +3440,130 @@ def _normalize_alphaess_cloud_data(cloud_data: dict) -> dict:
     return attrs
 
 
+class VoltxEnergyCoordinator(DataUpdateCoordinator):
+    """Coordinator for Voltx / Solplanet Modbus battery systems."""
+
+    _DEFAULT_FORCE_POWER_W = 5000.0
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        host: str,
+        port: int = 502,
+        slave_id: int = 3,
+        entry_id: str = "",
+    ) -> None:
+        from .inverters.voltx import VoltxController
+
+        self.host = host
+        self.port = port
+        self.slave_id = slave_id
+        self._entry_id = entry_id
+        # Reuse the native controller so polling and service handlers share the
+        # same Voltx register knowledge and connection behavior.
+        self._controller = VoltxController(host, port, slave_id)
+        self._energy_acc = EnergyAccumulator(hass, "voltx")
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_voltx_energy",
+            update_interval=UPDATE_INTERVAL_ENERGY,
+        )
+
+    def _resolve_force_power_w(self, requested_w: float, direction: str) -> float:
+        """Choose the requested power or a safe/device-reported default."""
+        if requested_w and requested_w > 0:
+            return float(requested_w)
+
+        field = (
+            "battery_max_charge_power_w"
+            if direction == "charge"
+            else "battery_max_discharge_power_w"
+        )
+        max_w = (self.data or {}).get(field)
+        if max_w and max_w > 0:
+            return float(max_w)
+        return self._DEFAULT_FORCE_POWER_W
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch Voltx telemetry and normalize it to PowerSync fields."""
+        if not self._energy_acc._last_update:
+            await self._energy_acc.async_restore()
+
+        try:
+            status = await self._controller.get_status()
+            attrs = status.attributes or {}
+            if "battery_soc" not in attrs:
+                raise UpdateFailed("Voltx Modbus returned no battery data")
+        except Exception as err:
+            if self.data:
+                return self.data
+            raise UpdateFailed(f"Error fetching Voltx energy data: {err}") from err
+
+        solar_kw = attrs.get("pv_power_kw", 0) or 0
+        grid_kw = attrs.get("grid_power_kw", 0) or 0
+        battery_kw = attrs.get("battery_power_kw", 0) or 0
+        load_kw = attrs.get("load_power_kw")
+        if load_kw is None:
+            # Voltx Modbus TCP does not expose the full CT/meter view, so use a
+            # simple balance fallback when the controller cannot infer load.
+            load_kw = solar_kw + grid_kw + battery_kw
+
+        buy, sell = _get_current_prices(self.hass, self._entry_id)
+        self._energy_acc.update(max(0, solar_kw), grid_kw, battery_kw, load_kw, buy, sell)
+
+        max_charge_w = attrs.get("battery_max_charge_power_w")
+        max_discharge_w = attrs.get("battery_max_discharge_power_w")
+
+        return {
+            "solar_power": solar_kw,
+            "grid_power": grid_kw,
+            "battery_power": battery_kw,
+            "load_power": load_kw,
+            "battery_level": attrs.get("battery_soc", 0),
+            "battery_soh": attrs.get("battery_soh"),
+            "battery_max_charge_power_w": max_charge_w,
+            "battery_max_discharge_power_w": max_discharge_w,
+            "battery_max_charge_power": (max_charge_w / 1000.0) if max_charge_w else None,
+            "battery_max_discharge_power": (max_discharge_w / 1000.0) if max_discharge_w else None,
+            "backup_reserve_percent": attrs.get("backup_reserve_percent"),
+            "work_mode_raw": attrs.get("work_mode_raw"),
+            "charge_power_command_w": attrs.get("charge_power_command_w"),
+            "last_update": dt_util.utcnow(),
+            "energy_summary": self._energy_acc.as_dict(),
+        }
+
+    async def force_charge(self, duration_minutes: int = 30, power_w: float = 0) -> bool:
+        """Force charge via Voltx custom mode."""
+        # PowerSync owns the countdown/auto-restore lifecycle; Voltx only needs
+        # the immediate custom-mode power command.
+        power_w = self._resolve_force_power_w(power_w, "charge")
+        async with self._controller:
+            return await self._controller.force_charge(power_kw=power_w / 1000.0)
+
+    async def force_discharge(self, duration_minutes: int = 30, power_w: float = 0) -> bool:
+        """Force discharge via Voltx custom mode."""
+        # Duration is handled in the shared service layer, not in the inverter.
+        power_w = self._resolve_force_power_w(power_w, "discharge")
+        async with self._controller:
+            return await self._controller.force_discharge(power_kw=power_w / 1000.0)
+
+    async def restore_normal(self) -> bool:
+        """Restore self-consumption mode."""
+        async with self._controller:
+            return await self._controller.restore_normal()
+
+    async def set_backup_reserve(self, percent: int) -> bool:
+        """Set Voltx minimum SOC reserve."""
+        async with self._controller:
+            return await self._controller.set_backup_reserve(percent)
+
+    async def async_shutdown(self) -> None:
+        """Disconnect controller on unload."""
+        await self._controller.disconnect()
+
+
 class SungrowEnergyCoordinator(DataUpdateCoordinator):
     """Coordinator to fetch Sungrow SH-series battery system data via Modbus.
 

--- a/custom_components/power_sync/inverters/voltx.py
+++ b/custom_components/power_sync/inverters/voltx.py
@@ -1,0 +1,329 @@
+"""Voltx inverter/battery controller via Modbus TCP.
+
+Supports Voltx / Solplanet hybrid inverter-battery systems that expose the
+AISWEI Modbus register map used by the proof-of-concept integration.
+
+Key control registers:
+- 1103: work mode (2=self-consumption, 4=custom)
+- 1152: signed charge/discharge power command (negative=charge, positive=discharge)
+- 1153: SOC max (% * 100)
+- 1154: SOC min (% * 100)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import struct
+from typing import Optional
+
+from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.exceptions import ModbusException
+import pymodbus
+
+from .base import InverterController, InverterState, InverterStatus
+
+_LOGGER = logging.getLogger(__name__)
+
+try:
+    _pymodbus_version = tuple(int(x) for x in pymodbus.__version__.split(".")[:2])
+    # pymodbus renamed the unit-id kwarg in 3.9; detect it once so the rest of
+    # the controller can stay agnostic to the installed library version.
+    _SLAVE_PARAM = "device_id" if _pymodbus_version >= (3, 9) else "slave"
+except Exception:
+    _SLAVE_PARAM = "slave"
+
+
+def _s16(raw: int) -> int:
+    """Interpret a raw u16 register as signed int16."""
+    return struct.unpack(">h", struct.pack(">H", raw & 0xFFFF))[0]
+
+
+def _s32(hi: int, lo: int) -> int:
+    """Combine two u16 registers into a signed int32."""
+    raw = ((hi & 0xFFFF) << 16) | (lo & 0xFFFF)
+    return struct.unpack(">i", struct.pack(">I", raw))[0]
+
+
+class VoltxController(InverterController):
+    """Controller for Voltx / Solplanet battery systems via Modbus TCP."""
+
+    REG_WORK_MODE = 1103
+    REG_CLOUD_STATUS = 1150
+    REG_CHPWR = 1152
+    REG_SOC_MAX = 1153
+    REG_SOC_MIN = 1154
+
+    WORK_MODE_SELF_CONSUMPTION = 2
+    WORK_MODE_RESERVE_POWER = 3
+    WORK_MODE_CUSTOM = 4
+    WORK_MODE_TOU = 5
+
+    DEFAULT_PORT = 502
+    DEFAULT_SLAVE_ID = 3
+    TIMEOUT_SECONDS = 10.0
+    DEFAULT_FORCE_POWER_W = 5000.0
+
+    def __init__(
+        self,
+        host: str,
+        port: int = DEFAULT_PORT,
+        slave_id: int = DEFAULT_SLAVE_ID,
+        model: Optional[str] = None,
+    ) -> None:
+        super().__init__(host, port, slave_id, model)
+        self._client: Optional[AsyncModbusTcpClient] = None
+        self._lock = asyncio.Lock()
+
+    async def connect(self) -> bool:
+        """Open the Modbus TCP connection."""
+        async with self._lock:
+            try:
+                if self._client and self._client.connected:
+                    return True
+
+                self._client = AsyncModbusTcpClient(
+                    host=self.host,
+                    port=self.port,
+                    timeout=self.TIMEOUT_SECONDS,
+                )
+                connected = await self._client.connect()
+                self._connected = connected
+                if not connected:
+                    _LOGGER.error(
+                        "Failed to connect to Voltx at %s:%s", self.host, self.port
+                    )
+                return connected
+            except Exception as err:
+                _LOGGER.error("Error connecting to Voltx: %s", err)
+                self._connected = False
+                return False
+
+    async def disconnect(self) -> None:
+        """Close the Modbus TCP connection."""
+        async with self._lock:
+            if self._client:
+                self._client.close()
+                self._client = None
+            self._connected = False
+
+    async def _read_input_registers(self, address: int, count: int) -> Optional[list[int]]:
+        """Read input registers."""
+        if not self._client or not self._client.connected:
+            if not await self.connect():
+                return None
+        try:
+            result = await self._client.read_input_registers(
+                address=address,
+                count=count,
+                **{_SLAVE_PARAM: self.slave_id},
+            )
+            if result.isError():
+                return None
+            return result.registers
+        except ModbusException as err:
+            _LOGGER.debug("Voltx input read failed at %d: %s", address, err)
+            return None
+        except Exception as err:
+            _LOGGER.debug("Voltx input read error at %d: %s", address, err)
+            return None
+
+    async def _read_holding_registers(self, address: int, count: int) -> Optional[list[int]]:
+        """Read holding registers."""
+        if not self._client or not self._client.connected:
+            if not await self.connect():
+                return None
+        try:
+            result = await self._client.read_holding_registers(
+                address=address,
+                count=count,
+                **{_SLAVE_PARAM: self.slave_id},
+            )
+            if result.isError():
+                return None
+            return result.registers
+        except ModbusException as err:
+            _LOGGER.debug("Voltx holding read failed at %d: %s", address, err)
+            return None
+        except Exception as err:
+            _LOGGER.debug("Voltx holding read error at %d: %s", address, err)
+            return None
+
+    async def _write_register(self, address: int, value: int) -> bool:
+        """Write a single holding register."""
+        if not self._client or not self._client.connected:
+            if not await self.connect():
+                return False
+        try:
+            result = await self._client.write_register(
+                address=address,
+                value=value & 0xFFFF,
+                **{_SLAVE_PARAM: self.slave_id},
+            )
+            if result.isError():
+                _LOGGER.warning("Voltx register write failed at %d: %s", address, result)
+                return False
+            return True
+        except ModbusException as err:
+            _LOGGER.warning("Voltx Modbus write failed at %d: %s", address, err)
+            return False
+        except Exception as err:
+            _LOGGER.warning("Voltx register write error at %d: %s", address, err)
+            return False
+
+    async def _write_force_mode(self, power_w: float) -> bool:
+        """Enable custom mode and set the signed charge/discharge power."""
+        power = int(round(power_w))
+        # PowerSync handles duration and auto-restore outside the inverter, so a
+        # force command only needs to enter custom mode and write the setpoint.
+        if not await self._write_register(self.REG_WORK_MODE, self.WORK_MODE_CUSTOM):
+            return False
+        return await self._write_register(self.REG_CHPWR, power)
+
+    async def force_charge(self, power_kw: float = 5.0) -> bool:
+        """Force charge using custom mode and a negative power setpoint."""
+        power_w = abs(power_kw * 1000) or self.DEFAULT_FORCE_POWER_W
+        return await self._write_force_mode(-power_w)
+
+    async def force_discharge(self, power_kw: float = 5.0) -> bool:
+        """Force discharge using custom mode and a positive power setpoint."""
+        power_w = abs(power_kw * 1000) or self.DEFAULT_FORCE_POWER_W
+        return await self._write_force_mode(power_w)
+
+    async def restore_normal(self) -> bool:
+        """Restore self-consumption mode and clear any custom power setpoint."""
+        ok = await self._write_register(self.REG_CHPWR, 0)
+        ok = await self._write_register(
+            self.REG_WORK_MODE, self.WORK_MODE_SELF_CONSUMPTION
+        ) and ok
+        return ok
+
+    async def set_self_consumption_mode(self) -> bool:
+        """Alias for restore_normal used by the generic service handler."""
+        return await self.restore_normal()
+
+    async def set_backup_reserve(self, percent: int) -> bool:
+        """Set the minimum SOC reserve percentage."""
+        percent = max(0, min(100, int(percent)))
+        return await self._write_register(self.REG_SOC_MIN, percent * 100)
+
+    async def get_backup_reserve(self) -> int | None:
+        """Read the currently configured minimum SOC reserve."""
+        regs = await self._read_holding_registers(self.REG_SOC_MIN, 1)
+        if not regs:
+            return None
+        return int(regs[0] // 100)
+
+    async def curtail(
+        self,
+        home_load_w: Optional[float] = None,
+        rated_capacity_w: Optional[float] = None,
+    ) -> bool:
+        """Voltx battery control does not implement separate solar curtailment."""
+        _LOGGER.warning("Voltx controller does not support AC inverter curtailment")
+        return False
+
+    async def restore(self) -> bool:
+        """Restore normal inverter operation."""
+        return await self.restore_normal()
+
+    async def get_status(self) -> InverterState:
+        """Read the current inverter and battery state."""
+        if not await self.connect():
+            return InverterState(
+                status=InverterStatus.OFFLINE,
+                is_curtailed=False,
+                error_message="Cannot connect to Voltx inverter",
+            )
+
+        inv_regs = await self._read_input_registers(1300, 80)
+        batt_status_regs = await self._read_input_registers(1606, 2)
+        batt_regs = await self._read_input_registers(1616, 13)
+        hold_regs = await self._read_holding_registers(1100, 55)
+
+        if not inv_regs or not batt_regs or not hold_regs:
+            return InverterState(
+                status=InverterStatus.ERROR,
+                is_curtailed=False,
+                error_message="Voltx inverter returned incomplete Modbus data",
+            )
+
+        pac_w = _s32(inv_regs[1370 - 1300], inv_regs[1371 - 1300])
+        grid_voltage = round(inv_regs[1358 - 1300] * 0.1, 1)
+        grid_current = round(inv_regs[1359 - 1300] * 0.1, 1)
+        grid_frequency = round(inv_regs[1367 - 1300] * 0.01, 2)
+        battery_power_w = _s32(batt_regs[2], batt_regs[3])
+        battery_voltage = round(batt_regs[0] * 0.01, 2)
+        battery_current = round(_s16(batt_regs[1]) * 0.1, 1)
+        battery_soc = batt_regs[5]
+        battery_soh = batt_regs[6]
+        charge_limit_a = round(batt_regs[7] * 0.1, 1)
+        discharge_limit_a = round(batt_regs[8] * 0.1, 1)
+        charge_energy_today = round(
+            (((batt_regs[9] & 0xFFFF) << 16) | (batt_regs[10] & 0xFFFF)) * 0.1, 1
+        )
+        discharge_energy_today = round(
+            (((batt_regs[11] & 0xFFFF) << 16) | (batt_regs[12] & 0xFFFF)) * 0.1, 1
+        )
+
+        work_mode_raw = hold_regs[self.REG_WORK_MODE - 1100]
+        charge_power_command_w = _s16(hold_regs[self.REG_CHPWR - 1100])
+        soc_max = hold_regs[self.REG_SOC_MAX - 1100] // 100
+        soc_min = hold_regs[self.REG_SOC_MIN - 1100] // 100
+
+        # The public Modbus TCP registers do not expose full site CT telemetry,
+        # so grid/load/solar are inferred from inverter active power and battery flow.
+        grid_power_kw = (-pac_w if pac_w < 0 else 0) / 1000.0
+        load_power_kw = max(0.0, (pac_w + max(0, grid_power_kw * 1000)) / 1000.0)
+        solar_power_kw = max(0.0, (pac_w - battery_power_w) / 1000.0)
+        battery_power_kw = battery_power_w / 1000.0
+        max_charge_power_w = round(charge_limit_a * battery_voltage)
+        max_discharge_power_w = round(discharge_limit_a * battery_voltage)
+
+        attributes = {
+            "ac_power_kw": pac_w / 1000.0,
+            "pv_power_kw": solar_power_kw,
+            "grid_power_kw": grid_power_kw,
+            "load_power_kw": load_power_kw,
+            "battery_power_kw": battery_power_kw,
+            "battery_soc": battery_soc,
+            "battery_soh": battery_soh,
+            "battery_voltage_v": battery_voltage,
+            "battery_current_a": battery_current,
+            "battery_temperature_c": round(_s16(batt_regs[4]) * 0.1, 1),
+            "grid_voltage_v": grid_voltage,
+            "grid_current_a": grid_current,
+            "grid_frequency_hz": grid_frequency,
+            "charge_energy_today_kwh": charge_energy_today,
+            "discharge_energy_today_kwh": discharge_energy_today,
+            "battery_max_charge_power_w": max_charge_power_w,
+            "battery_max_discharge_power_w": max_discharge_power_w,
+            "battery_max_charge_power_kw": max_charge_power_w / 1000.0,
+            "battery_max_discharge_power_kw": max_discharge_power_w / 1000.0,
+            "work_mode_raw": work_mode_raw,
+            "charge_power_command_w": charge_power_command_w,
+            "backup_reserve_percent": soc_min,
+            "battery_soc_max": soc_max,
+            "cloud_status_raw": hold_regs[self.REG_CLOUD_STATUS - 1100],
+        }
+        if batt_status_regs and len(batt_status_regs) >= 2:
+            attributes["battery_comm_status"] = batt_status_regs[0]
+            attributes["battery_status_raw"] = batt_status_regs[1]
+
+        state = InverterState(
+            status=InverterStatus.ONLINE,
+            is_curtailed=False,
+            power_output_w=float(pac_w),
+            attributes=attributes,
+        )
+        self._last_state = state
+        return state
+
+    async def __aenter__(self):
+        """Context manager entry."""
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        await self.disconnect()

--- a/custom_components/power_sync/optimization/battery_controller.py
+++ b/custom_components/power_sync/optimization/battery_controller.py
@@ -193,8 +193,9 @@ class BatteryControllerWrapper:
             for entry_id, entry_data in self.hass.data.get(DOMAIN, {}).items():
                 if not isinstance(entry_data, dict):
                     continue
-                # Modbus-based batteries: read from controller
-                for coord_key in ("sigenergy_coordinator", "sungrow_coordinator", "foxess_coordinator", "goodwe_coordinator"):
+                # Modbus-based batteries: read from controller. Voltx follows
+                # the same native coordinator/controller pattern as the others.
+                for coord_key in ("sigenergy_coordinator", "sungrow_coordinator", "foxess_coordinator", "goodwe_coordinator", "voltx_coordinator"):
                     coord = entry_data.get(coord_key)
                     if coord and hasattr(coord, "_controller") and hasattr(coord._controller, "get_backup_reserve"):
                         return await coord._controller.get_backup_reserve()

--- a/custom_components/power_sync/sensor.py
+++ b/custom_components/power_sync/sensor.py
@@ -796,6 +796,7 @@ async def async_setup_entry(
     foxess_coordinator = domain_data.get("foxess_coordinator")
     goodwe_coordinator = domain_data.get("goodwe_coordinator")
     alphaess_coordinator = domain_data.get("alphaess_coordinator")
+    voltx_coordinator = domain_data.get("voltx_coordinator")
     demand_charge_coordinator: DemandChargeCoordinator | None = domain_data.get("demand_charge_coordinator")
     aemo_spike_manager = domain_data.get("aemo_spike_manager")
     is_sigenergy = domain_data.get("is_sigenergy", False)
@@ -803,6 +804,7 @@ async def async_setup_entry(
     is_foxess = domain_data.get("is_foxess", False)
     is_goodwe = domain_data.get("is_goodwe", False)
     is_alphaess = domain_data.get("is_alphaess", False)
+    is_voltx = domain_data.get("is_voltx", False)
 
     entities: list[SensorEntity] = []
 
@@ -876,6 +878,10 @@ async def async_setup_entry(
         energy_coordinator = sigenergy_coordinator
     elif is_alphaess:
         energy_coordinator = alphaess_coordinator
+    elif is_voltx:
+        # Voltx exposes the same normalized energy keys as the other native
+        # battery coordinators, so the shared sensor set can consume it directly.
+        energy_coordinator = voltx_coordinator
     else:
         energy_coordinator = tesla_coordinator
     if energy_coordinator:
@@ -1214,6 +1220,10 @@ async def async_setup_entry(
         battery_system = "sigenergy"
     elif is_alphaess:
         battery_system = "alphaess"
+    elif is_voltx:
+        # BatteryHealthSensor uses the battery-system tag to decide which SOH
+        # field to read from coordinator data, so Voltx needs its own label here.
+        battery_system = "voltx"
     entities.append(BatteryHealthSensor(
         entry=entry,
         coordinator=energy_coordinator,

--- a/custom_components/power_sync/strings.json
+++ b/custom_components/power_sync/strings.json
@@ -434,6 +434,21 @@
         },
         "submit": "Connect"
       },
+      "voltx_connection": {
+        "title": "Voltx Modbus connection",
+        "description": "Connect to your Voltx / Solplanet inverter over Modbus TCP for battery telemetry and control.",
+        "data": {
+          "voltx_host": "Inverter IP address",
+          "voltx_port": "Modbus port",
+          "voltx_slave_id": "Modbus slave ID"
+        },
+        "data_description": {
+          "voltx_host": "Local IP address of your Voltx / Solplanet inverter.",
+          "voltx_port": "Default Modbus TCP port is 502.",
+          "voltx_slave_id": "Default is 3 on the verified Solplanet/Voltx register map."
+        },
+        "submit": "Connect"
+      },
       "sigenergy_credentials": {
         "title": "Sigenergy Cloud login",
         "description": "Enter your Sigenergy Cloud API credentials to connect your system.",
@@ -705,6 +720,9 @@
       "foxess_cloud_connection_error": "Cannot reach FoxESS Cloud. Check your internet connection and retry.",
       "goodwe_connect_failed": "Cannot connect to GoodWe inverter. Verify the IP address is correct and the inverter is powered on and reachable from Home Assistant.",
       "goodwe_no_battery": "This GoodWe model (DT/MS/XS series) does not support battery control. Only ET/EH/ES/EM series hybrid inverters are supported.",
+      "voltx_host_required": "IP address is required -- enter the local IP of your Voltx / Solplanet inverter.",
+      "voltx_connection_failed": "Cannot connect to the Voltx inverter. Check the IP address, Modbus port, slave ID, and that the inverter is reachable from Home Assistant.",
+      "voltx_no_data": "Connected to the Voltx inverter but no battery telemetry was returned. Verify the slave ID and that the battery is online.",
       "invalid_credentials": "Email or password is incorrect. Check your Flow Power portal login credentials.",
       "invalid_mfa_code": "Verification code is incorrect or expired. Request a new SMS code and try again.",
       "zaptec_auth_failed": "Zaptec Cloud login failed. Check that your email and password are correct.",
@@ -736,6 +754,7 @@
           "sungrow_connection": "Sungrow Modbus connection",
           "foxess_connection_options": "FoxESS connection",
           "goodwe_connection_options": "GoodWe connection",
+          "voltx_connection_options": "Voltx connection",
           "optimization": "Optimization mode",
           "inverter": "AC inverter curtailment",
           "curtailment": "Curtailment settings",
@@ -855,6 +874,21 @@
           "goodwe_host": "Local IP address of your GoodWe inverter.",
           "goodwe_protocol": "UDP for WiFi dongles (port 8899), TCP for LAN dongles (port 502).",
           "goodwe_port": "Default: 8899 for UDP, 502 for TCP."
+        },
+        "submit": "Save"
+      },
+      "voltx_connection_options": {
+        "title": "Voltx connection",
+        "description": "Update your Voltx / Solplanet inverter Modbus settings. Changes take effect immediately.",
+        "data": {
+          "voltx_host": "Inverter IP address",
+          "voltx_port": "Modbus port",
+          "voltx_slave_id": "Modbus slave ID"
+        },
+        "data_description": {
+          "voltx_host": "Local IP address of your Voltx / Solplanet inverter.",
+          "voltx_port": "Default Modbus TCP port is 502.",
+          "voltx_slave_id": "Default is 3 on the verified Solplanet/Voltx register map."
         },
         "submit": "Save"
       },

--- a/custom_components/power_sync/translations/en.json
+++ b/custom_components/power_sync/translations/en.json
@@ -434,6 +434,21 @@
         },
         "submit": "Connect"
       },
+      "voltx_connection": {
+        "title": "Voltx Modbus connection",
+        "description": "Connect to your Voltx / Solplanet inverter over Modbus TCP for battery telemetry and control.",
+        "data": {
+          "voltx_host": "Inverter IP address",
+          "voltx_port": "Modbus port",
+          "voltx_slave_id": "Modbus slave ID"
+        },
+        "data_description": {
+          "voltx_host": "Local IP address of your Voltx / Solplanet inverter.",
+          "voltx_port": "Default Modbus TCP port is 502.",
+          "voltx_slave_id": "Default is 3 on the verified Solplanet/Voltx register map."
+        },
+        "submit": "Connect"
+      },
       "sigenergy_credentials": {
         "title": "Sigenergy Cloud login",
         "description": "Enter your Sigenergy Cloud API credentials to connect your system.",
@@ -705,6 +720,9 @@
       "foxess_cloud_connection_error": "Cannot reach FoxESS Cloud. Check your internet connection and retry.",
       "goodwe_connect_failed": "Cannot connect to GoodWe inverter. Verify the IP address is correct and the inverter is powered on and reachable from Home Assistant.",
       "goodwe_no_battery": "This GoodWe model (DT/MS/XS series) does not support battery control. Only ET/EH/ES/EM series hybrid inverters are supported.",
+      "voltx_host_required": "IP address is required -- enter the local IP of your Voltx / Solplanet inverter.",
+      "voltx_connection_failed": "Cannot connect to the Voltx inverter. Check the IP address, Modbus port, slave ID, and that the inverter is reachable from Home Assistant.",
+      "voltx_no_data": "Connected to the Voltx inverter but no battery telemetry was returned. Verify the slave ID and that the battery is online.",
       "invalid_credentials": "Email or password is incorrect. Check your Flow Power portal login credentials.",
       "invalid_mfa_code": "Verification code is incorrect or expired. Request a new SMS code and try again.",
       "zaptec_auth_failed": "Zaptec Cloud login failed. Check that your email and password are correct.",
@@ -736,6 +754,7 @@
           "sungrow_connection": "Sungrow Modbus connection",
           "foxess_connection_options": "FoxESS connection",
           "goodwe_connection_options": "GoodWe connection",
+          "voltx_connection_options": "Voltx connection",
           "optimization": "Optimization mode",
           "inverter": "AC inverter curtailment",
           "curtailment": "Curtailment settings",
@@ -855,6 +874,21 @@
           "goodwe_host": "Local IP address of your GoodWe inverter.",
           "goodwe_protocol": "UDP for WiFi dongles (port 8899), TCP for LAN dongles (port 502).",
           "goodwe_port": "Default: 8899 for UDP, 502 for TCP."
+        },
+        "submit": "Save"
+      },
+      "voltx_connection_options": {
+        "title": "Voltx connection",
+        "description": "Update your Voltx / Solplanet inverter Modbus settings. Changes take effect immediately.",
+        "data": {
+          "voltx_host": "Inverter IP address",
+          "voltx_port": "Modbus port",
+          "voltx_slave_id": "Modbus slave ID"
+        },
+        "data_description": {
+          "voltx_host": "Local IP address of your Voltx / Solplanet inverter.",
+          "voltx_port": "Default Modbus TCP port is 502.",
+          "voltx_slave_id": "Default is 3 on the verified Solplanet/Voltx register map."
         },
         "submit": "Save"
       },


### PR DESCRIPTION
Voltx support is implemented as a native PowerSync battery system. It adds a new voltx inverter/controller, config-flow setup for host/port/slave ID, a Voltx energy coordinator, sensor selection, optimizer compatibility, and service routing for force charge, force discharge, restore normal, and reserve/self-consumption handling.
Duration-based auto-restore uses PowerSync’s existing timer machinery, so no Voltx-specific duration register hack was needed.

Voltx added through the main runtime registration paths and explicitly left solar curtailment unsupported for Voltx because the reference Modbus work shows grid/load CT data is not available over the inverter’s Modbus TCP interface.