### PR TITLE
fix(foxess): correct H3-Smart battery voltage scaling factor (100→10)

### DIFF
--- a/custom_components/power_sync/inverters/foxess.py
+++ b/custom_components/power_sync/inverters/foxess.py
@@ -67,7 +67,7 @@ class FoxESSRegisterMap:
     battery_power: int          # Scaled by battery_pv_gain, signed (neg=charge, pos=discharge)
     battery_power_is_32bit: bool = False  # H3-Pro uses 32-bit battery power
     battery_voltage: int = 0
-    battery_voltage_gain: int = GAIN_VOLTAGE   # default scale 0.1 V; H3-Smart uses 100 (scale 0.01 V)
+    battery_voltage_gain: int = GAIN_VOLTAGE   # scale 0.1 V
     battery_current: int = 0
     battery_temperature: int = 0
 
@@ -270,8 +270,7 @@ REGISTER_MAPS: dict[FoxESSModelFamily, FoxESSRegisterMap] = {
         battery_soc=37612,
         battery_power=39238,      # 32-bit: scale 0.001
         battery_power_is_32bit=True,
-        battery_voltage=39227,    # pack voltage, scale 0.01 (gain 100)
-        battery_voltage_gain=100,
+        battery_voltage=39227,    # pack voltage, scale 0.1
         battery_current=37610,    # BMS1 Current
         battery_temperature=37611,  # BMS1 Ambient Temperature
         nominal_power_w=39053,    # 32-bit: 39053 (high) + 39054 (low), scale 1.0


### PR DESCRIPTION
## Summary

- `battery_voltage_gain` for the H3-Smart register map was set to `100` instead of the correct `10`, causing battery voltage to be reported 10× too low (e.g. 484.5 V read as 48.5 V).
- Since `10` is already the default value (`GAIN_VOLTAGE`), the explicit override is simply removed rather than corrected — along with the now-stale comment on the dataclass field.

## Effect

Without the fix, the coordinator logged:

```
WARNING  FoxESS force_charge: live battery voltage unavailable (got 47.7), falling back to 500V based on model family H3-Smart
INFO     FoxESS force_charge using inverter max: 32A × 500V → 16000W
```

With the fix, the real pack voltage (~480–560 V) is used directly.

## Test plan

- [ ] Verify battery voltage sensor now reads correctly on an H3-Smart inverter
- [ ] Confirm `live battery voltage unavailable` warning no longer appears in coordinator logs
- [ ] Confirm force-charge calculation uses live voltage rather than the 500 V fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)