### PR TITLE
fix(frontend): isolate energy flow scene background

### DIFF
--- a/custom_components/power_sync/frontend/power-sync-energy-flow.js
+++ b/custom_components/power_sync/frontend/power-sync-energy-flow.js
@@ -14,7 +14,6 @@ import {
   const FLOW_MIN_W = 50;
   const SVG_WIDTH = 600;
   const SVG_HEIGHT = 460;
-  const XLINK_NS = 'http://www.w3.org/1999/xlink';
   const SUPPORTED_LANGS = ['it', 'en', 'es', 'fr', 'de'];
   const DEFAULT_LANG = 'it';
   const LANGUAGE_OPTIONS = Object.freeze([
@@ -1050,6 +1049,14 @@ import {
     return `${x.toFixed(2)} ${y.toFixed(2)} ${width.toFixed(2)} ${height.toFixed(2)}`;
   }
 
+  function cssBackgroundUrl(url) {
+    const safeUrl = String(url || '')
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '');
+    return `url("${safeUrl}")`;
+  }
+
   function safeNum(value, fallback = 0) {
     const n = parseFloat(value);
     return Number.isFinite(n) ? n : fallback;
@@ -1265,6 +1272,8 @@ import {
       this._lastAppliedSceneFlowComponentProfile = '';
       this._pendingFlowStates = null;
       this._renderQueued = false;
+      this._preloadedSceneBackgrounds = new Set();
+      this._backgroundLoadToken = 0;
     }
 
     setConfig(config) {
@@ -1604,12 +1613,31 @@ import {
     }
 
     _setBackground(url) {
-      const img = this.shadowRoot.querySelector('#flow-scene-image');
-      if (!img || !url) return;
-      if (img.getAttribute('href') !== url || img.getAttributeNS(XLINK_NS, 'href') !== url) {
-        img.setAttribute('href', url);
-        img.setAttributeNS(XLINK_NS, 'xlink:href', url);
+      const frame = this.shadowRoot.querySelector('#flow-scene-frame');
+      if (!frame || !url) return;
+      if (frame.dataset.sceneBackground === url || frame.dataset.pendingSceneBackground === url) return;
+
+      const token = ++this._backgroundLoadToken;
+      frame.dataset.pendingSceneBackground = url;
+      const applyBackground = () => {
+        if (token !== this._backgroundLoadToken) return;
+        frame.style.setProperty('--scene-background', cssBackgroundUrl(url));
+        frame.dataset.sceneBackground = url;
+        delete frame.dataset.pendingSceneBackground;
+      };
+
+      if (this._preloadedSceneBackgrounds.has(url) || typeof Image === 'undefined') {
+        applyBackground();
+        return;
       }
+
+      const image = new Image();
+      image.onload = () => {
+        this._preloadedSceneBackgrounds.add(url);
+        applyBackground();
+      };
+      image.onerror = applyBackground;
+      image.src = url;
     }
 
     _initialPathProfile() {
@@ -1719,13 +1747,29 @@ import {
           .scene {
             padding: 10px;
           }
-          svg {
-            width: 100%;
-            height: auto;
-            display: block;
+          .scene-frame {
+            position: relative;
+            overflow: hidden;
+            aspect-ratio: ${SVG_WIDTH} / ${SVG_HEIGHT};
             border-radius: 12px;
             border: 1px solid rgba(255,255,255,0.08);
             background: #020617;
+          }
+          .scene-frame::before {
+            content: '';
+            position: absolute;
+            inset: var(--scene-background-inset, 0);
+            background-image: var(--scene-background, none);
+            background-position: center;
+            background-repeat: no-repeat;
+            background-size: cover;
+          }
+          svg {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            display: block;
           }
           .flow-scene-dim {
             fill: #020617;
@@ -1733,7 +1777,7 @@ import {
           }
           .flow-node-bg {
             fill: rgba(255,255,255,0.08);
-            transition: fill 0.2s ease, filter 0.2s ease;
+            transition: fill 0.2s ease;
             display: none;
           }
           .flow-node-bg.active {
@@ -1914,21 +1958,21 @@ import {
           <div class="wrap ${showLabelsClass}">
             ${titleHtml}
             <div class="scene">
-              <svg viewBox="${sceneViewBox}" xmlns:xlink="${XLINK_NS}">
-                <image id="flow-scene-image" href="${cfg.background}" xlink:href="${cfg.background}" x="0" y="0" width="600" height="460" preserveAspectRatio="xMidYMid slice"></image>
-                <rect class="flow-scene-dim" x="0" y="0" width="600" height="460"></rect>
+              <div class="scene-frame" id="flow-scene-frame">
+                <svg viewBox="${sceneViewBox}">
+                  <rect class="flow-scene-dim" x="0" y="0" width="600" height="460"></rect>
 
-                <path id="line-solar-load" class="flow-line" d="${pathD('line-solar-load', 'line_solar_load')}"></path>
-                <path id="line-grid-load" class="flow-line" d="${pathD('line-grid-load', 'line_grid_load')}"></path>
-                <path id="line-battery-load" class="flow-line" d="${pathD('line-battery-load', 'line_battery_load')}"></path>
-                <path id="line-junction-home-load" class="flow-line" d="${pathD('line-junction-home-load', 'line_junction_home_load')}"></path>
-                <path id="line-wallbox-ev" class="flow-line" d="${pathD('line-wallbox-ev', 'line_wallbox_ev')}"></path>
-                <path id="line-wallbox-ev2" class="flow-line" d="${pathD('line-wallbox-ev2', 'line_wallbox_ev2')}"></path>
-                <path id="line-solar-grid" class="flow-line" d="${pathD('line-solar-grid', 'line_solar_grid')}"></path>
-                <path id="line-solar-battery" class="flow-line" d="${pathD('line-solar-battery', 'line_solar_battery')}"></path>
-                <path id="line-grid-battery" class="flow-line" d="${pathD('line-grid-battery', 'line_grid_battery')}"></path>
+                  <path id="line-solar-load" class="flow-line" d="${pathD('line-solar-load', 'line_solar_load')}"></path>
+                  <path id="line-grid-load" class="flow-line" d="${pathD('line-grid-load', 'line_grid_load')}"></path>
+                  <path id="line-battery-load" class="flow-line" d="${pathD('line-battery-load', 'line_battery_load')}"></path>
+                  <path id="line-junction-home-load" class="flow-line" d="${pathD('line-junction-home-load', 'line_junction_home_load')}"></path>
+                  <path id="line-wallbox-ev" class="flow-line" d="${pathD('line-wallbox-ev', 'line_wallbox_ev')}"></path>
+                  <path id="line-wallbox-ev2" class="flow-line" d="${pathD('line-wallbox-ev2', 'line_wallbox_ev2')}"></path>
+                  <path id="line-solar-grid" class="flow-line" d="${pathD('line-solar-grid', 'line_solar_grid')}"></path>
+                  <path id="line-solar-battery" class="flow-line" d="${pathD('line-solar-battery', 'line_solar_battery')}"></path>
+                  <path id="line-grid-battery" class="flow-line" d="${pathD('line-grid-battery', 'line_grid_battery')}"></path>
 
-                <g class="flow-node">
+                  <g class="flow-node">
                   <circle class="flow-node-bg" id="node-solar-bg" cx="286" cy="155" r="5"></circle>
                   <line class="flow-node-guide" id="flow-solar-guide" x1="320" y1="94" x2="320" y2="166"></line>
                   <text class="flow-label" id="flow-solar-label" x="329" y="60">${this._t('card.node.solar', 'Solare')}</text>
@@ -1994,10 +2038,17 @@ import {
                   <text class="flow-status" id="flow-ev2-status" x="106" y="340">${this._t('card.status.off', 'OFF')}</text>
                 </g>
               </svg>
+              </div>
             </div>
           </div>
         </ha-card>
       `;
+      const frame = this.shadowRoot.querySelector('#flow-scene-frame');
+      if (frame) {
+        const backgroundInset = `${((1 - sceneScale) * 50).toFixed(2)}%`;
+        frame.style.setProperty('--scene-background-inset', backgroundInset);
+      }
+      this._setBackground(cfg.background);
       this._initialized = true;
     }
 

--- a/tests/energy_flow_stress_harness.html
+++ b/tests/energy_flow_stress_harness.html
@@ -1,0 +1,241 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>PowerSync Energy Flow Stress Harness</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #111827;
+        color: #e5e7eb;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      main {
+        max-width: 820px;
+        margin: 0 auto;
+      }
+      .panel {
+        margin-top: 16px;
+        padding: 12px 14px;
+        border: 1px solid rgba(255,255,255,0.12);
+        background: rgba(17,24,39,0.82);
+        border-radius: 8px;
+      }
+      pre {
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      power-sync-energy-flow {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <power-sync-energy-flow id="card"></power-sync-energy-flow>
+      <div class="panel">
+        <pre data-testid="result" id="result">Starting stress test...</pre>
+      </div>
+    </main>
+
+    <script>
+      window.addEventListener('error', function (event) {
+        var result = document.getElementById('result');
+        if (result && result.textContent.indexOf('Starting stress test') === 0) {
+          result.textContent = 'BOOT FAIL\n' + (event.message || 'Script failed to load') +
+            (event.filename ? '\n\n' + event.filename : '');
+        }
+      });
+      window.setTimeout(function () {
+        var result = document.getElementById('result');
+        if (result && result.textContent.indexOf('Starting stress test') === 0) {
+          result.textContent = 'BOOT FAIL\nThe stress harness did not start. Open it through the local HTTP server URL, not directly from Finder/Safari as a file.';
+        }
+      }, 4000);
+    </script>
+
+    <script type="module">
+      const resultEl = document.getElementById('result');
+      const card = document.getElementById('card');
+      const startupErrors = [];
+      const showFailure = (message, error) => {
+        const details = error && (error.stack || error.message || String(error));
+        resultEl.textContent = `BOOT FAIL\n${message}${details ? `\n\n${details}` : ''}`;
+      };
+      window.addEventListener('error', (event) => {
+        startupErrors.push(event.message || String(event.error || event));
+      });
+      window.addEventListener('unhandledrejection', (event) => {
+        startupErrors.push(String(event.reason || event));
+      });
+
+      try {
+        await import('../custom_components/power_sync/frontend/power-sync-energy-flow.js');
+        await customElements.whenDefined('power-sync-energy-flow');
+      } catch (error) {
+        showFailure(
+          'Could not import the PowerSync card module. Open this page through the local HTTP server, not as a file:// URL.',
+          error
+        );
+        throw error;
+      }
+
+      const metrics = {
+        ticks: 0,
+        renderDynamicCalls: 0,
+        setBackgroundCalls: 0,
+        backgroundChanges: 0,
+        observedBackgrounds: [],
+        consoleErrors: startupErrors,
+        passed: false
+      };
+
+      window.addEventListener('error', (event) => {
+        metrics.consoleErrors.push(event.message || String(event.error || event));
+      });
+      window.addEventListener('unhandledrejection', (event) => {
+        metrics.consoleErrors.push(String(event.reason || event));
+      });
+
+      card.setConfig({
+        title: 'PowerSync Stress Harness',
+        language: 'en',
+        dynamic_background: true,
+        background: '/custom_components/power_sync/frontend/backgrounds/scene_day_clear_idle.png',
+        background_asset_base: '/custom_components/power_sync/frontend/backgrounds',
+        scene_scale: 1.06,
+        entities: {
+          solar_power: 'sensor.solar_power',
+          roof_a_power: 'sensor.roof_a_power',
+          roof_a_voltage: 'sensor.roof_a_voltage',
+          roof_a_current: 'sensor.roof_a_current',
+          roof_b_power: 'sensor.roof_b_power',
+          roof_b_voltage: 'sensor.roof_b_voltage',
+          roof_b_current: 'sensor.roof_b_current',
+          grid_power: 'sensor.grid_power',
+          battery_power: 'sensor.battery_power',
+          load_power: 'sensor.load_power',
+          battery_level: 'sensor.battery_level',
+          ev_power: 'sensor.ev_power',
+          ev_battery: 'sensor.ev_battery',
+          ev_charge_switch: 'switch.ev_charge',
+          ev_presence: 'binary_sensor.ev_presence',
+          ev2_power: 'sensor.ev2_power',
+          ev2_battery: 'sensor.ev2_battery',
+          ev2_charge_switch: 'switch.ev2_charge',
+          ev2_presence: 'binary_sensor.ev2_presence',
+          weather: 'weather.home',
+          sun: 'sun.sun'
+        }
+      });
+
+      const originalRenderDynamic = card._renderDynamic.bind(card);
+      card._renderDynamic = () => {
+        metrics.renderDynamicCalls += 1;
+        originalRenderDynamic();
+      };
+      const originalSetBackground = card._setBackground.bind(card);
+      card._setBackground = (url) => {
+        metrics.setBackgroundCalls += 1;
+        originalSetBackground(url);
+      };
+
+      function entity(entity_id, state, attributes = {}) {
+        const now = new Date().toISOString();
+        return { entity_id, state: String(state), attributes, last_changed: now, last_updated: now };
+      }
+
+      function hassForTick(tick) {
+        const phase = tick / 8;
+        const charging = tick % 80 >= 35;
+        const dual = tick % 140 >= 95;
+        const night = tick % 120 >= 60;
+        const weatherStates = ['sunny', 'cloudy', 'rainy', 'lightning', 'snowy'];
+        const weather = weatherStates[Math.floor(tick / 28) % weatherStates.length];
+        const solar = night ? Math.max(0, 120 * Math.sin(phase)) : 2400 + 850 * Math.sin(phase);
+        const evPower = charging ? 2800 + 250 * Math.sin(phase * 1.7) : 0;
+        const ev2Power = dual ? 1700 + 200 * Math.cos(phase * 1.3) : 0;
+        const battery = tick % 64 < 32 ? 950 + 180 * Math.sin(phase) : -820 - 160 * Math.cos(phase);
+        const load = 1600 + evPower + ev2Power + 280 * Math.cos(phase);
+        const grid = load + Math.max(0, battery) - solar - Math.max(0, -battery);
+        return {
+          language: 'en',
+          selectedLanguage: 'en',
+          states: {
+            'sensor.solar_power': entity('sensor.solar_power', solar.toFixed(0), { unit_of_measurement: 'W', friendly_name: 'Solar Power' }),
+            'sensor.roof_a_power': entity('sensor.roof_a_power', (solar * 0.55).toFixed(0), { unit_of_measurement: 'W', friendly_name: 'Roof A Power' }),
+            'sensor.roof_a_voltage': entity('sensor.roof_a_voltage', '356', { unit_of_measurement: 'V', friendly_name: 'Roof A Voltage' }),
+            'sensor.roof_a_current': entity('sensor.roof_a_current', '5.6', { unit_of_measurement: 'A', friendly_name: 'Roof A Current' }),
+            'sensor.roof_b_power': entity('sensor.roof_b_power', (solar * 0.45).toFixed(0), { unit_of_measurement: 'W', friendly_name: 'Roof B Power' }),
+            'sensor.roof_b_voltage': entity('sensor.roof_b_voltage', '348', { unit_of_measurement: 'V', friendly_name: 'Roof B Voltage' }),
+            'sensor.roof_b_current': entity('sensor.roof_b_current', '4.9', { unit_of_measurement: 'A', friendly_name: 'Roof B Current' }),
+            'sensor.grid_power': entity('sensor.grid_power', grid.toFixed(0), { unit_of_measurement: 'W', friendly_name: 'Grid Power' }),
+            'sensor.battery_power': entity('sensor.battery_power', battery.toFixed(0), { unit_of_measurement: 'W', friendly_name: 'Battery Power' }),
+            'sensor.load_power': entity('sensor.load_power', load.toFixed(0), { unit_of_measurement: 'W', friendly_name: 'Home Load' }),
+            'sensor.battery_level': entity('sensor.battery_level', 62 + (tick % 25), { unit_of_measurement: '%', friendly_name: 'Battery Level' }),
+            'sensor.ev_power': entity('sensor.ev_power', evPower.toFixed(0), { unit_of_measurement: 'W', friendly_name: 'EV Power' }),
+            'sensor.ev_battery': entity('sensor.ev_battery', 42 + (tick % 50), { unit_of_measurement: '%', friendly_name: 'EV Battery' }),
+            'switch.ev_charge': entity('switch.ev_charge', charging ? 'on' : 'off', { friendly_name: 'EV Charge' }),
+            'binary_sensor.ev_presence': entity('binary_sensor.ev_presence', charging ? 'on' : 'off', { friendly_name: 'EV Presence' }),
+            'sensor.ev2_power': entity('sensor.ev2_power', ev2Power.toFixed(0), { unit_of_measurement: 'W', friendly_name: 'EV 2 Power' }),
+            'sensor.ev2_battery': entity('sensor.ev2_battery', 28 + (tick % 60), { unit_of_measurement: '%', friendly_name: 'EV 2 Battery' }),
+            'switch.ev2_charge': entity('switch.ev2_charge', dual ? 'on' : 'off', { friendly_name: 'EV 2 Charge' }),
+            'binary_sensor.ev2_presence': entity('binary_sensor.ev2_presence', dual ? 'on' : 'off', { friendly_name: 'EV 2 Presence' }),
+            'weather.home': entity('weather.home', weather, { friendly_name: 'Home Weather' }),
+            'sun.sun': entity('sun.sun', night ? 'below_horizon' : 'above_horizon', { friendly_name: 'Sun' })
+          }
+        };
+      }
+
+      let lastBackground = '';
+      function sample() {
+        const frame = card.shadowRoot?.querySelector('#flow-scene-frame');
+        const nextBackground = frame?.dataset?.sceneBackground || '';
+        if (nextBackground && nextBackground !== lastBackground) {
+          metrics.backgroundChanges += 1;
+          metrics.observedBackgrounds.push(nextBackground.split('/').pop());
+          lastBackground = nextBackground;
+        }
+      }
+
+      const interval = setInterval(() => {
+        metrics.ticks += 1;
+        card.hass = hassForTick(metrics.ticks);
+        sample();
+      }, 40);
+
+      setTimeout(() => {
+        clearInterval(interval);
+        setTimeout(() => {
+          sample();
+          const shadow = card.shadowRoot;
+          const frame = shadow?.querySelector('#flow-scene-frame');
+          const diagnostics = {
+            ...metrics,
+            framePresent: !!frame,
+            svgImageCount: shadow?.querySelectorAll('svg image').length ?? -1,
+            activeLineCount: shadow?.querySelectorAll('.flow-line.active').length ?? -1,
+            pendingAtEnd: frame?.dataset?.pendingSceneBackground || '',
+            currentBackground: frame?.dataset?.sceneBackground?.split('/').pop() || '',
+            cssBackgroundSet: !!frame?.style?.getPropertyValue('--scene-background')
+          };
+          diagnostics.passed = (
+            diagnostics.ticks >= 150 &&
+            diagnostics.renderDynamicCalls >= 120 &&
+            diagnostics.framePresent &&
+            diagnostics.svgImageCount === 0 &&
+            diagnostics.activeLineCount > 0 &&
+            diagnostics.backgroundChanges >= 3 &&
+            !diagnostics.pendingAtEnd &&
+            diagnostics.cssBackgroundSet &&
+            diagnostics.consoleErrors.length === 0
+          );
+          resultEl.textContent = `DONE ${diagnostics.passed ? 'PASS' : 'FAIL'}\n${JSON.stringify(diagnostics, null, 2)}`;
+        }, 600);
+      }, 7000);
+    </script>
+  </body>
+</html>

--- a/tests/test_energy_flow_frontend.py
+++ b/tests/test_energy_flow_frontend.py
@@ -14,12 +14,15 @@ ENERGY_FLOW_PATH = (
 )
 
 
-def test_energy_flow_uses_webkit_safe_svg_image_and_scaling():
+def test_energy_flow_keeps_scene_bitmap_outside_animated_svg_layer():
     source = ENERGY_FLOW_PATH.read_text()
 
-    assert "xlink:href" in source
-    assert "setAttributeNS(XLINK_NS, 'xlink:href', url)" in source
-    assert "getAttributeNS(XLINK_NS, 'href')" in source
+    assert 'id="flow-scene-frame"' in source
+    assert "--scene-background" in source
+    assert "cssBackgroundUrl(url)" in source
+    assert "new Image()" in source
+    assert '<image id="flow-scene-image"' not in source
+    assert "xlink:href" not in source
     assert "function scaledSceneViewBox(scale)" in source
     assert 'viewBox="${sceneViewBox}"' in source
     assert "transform: scale" not in source


### PR DESCRIPTION
Moves the energy-flow house scene bitmap out of the animated SVG layer and into a preloaded CSS background layer to avoid Safari/WebKit repaint flicker during live state updates. Updates frontend regression coverage and adds a stress harness for rapid HA-style updates and scene swaps.

Tested:
- node --check custom_components/power_sync/frontend/power-sync-energy-flow.js
- frontend regression assertions
- git diff --check
- browser stress harness: PASS, 175 rapid updates, 14 scene swaps, no console errors