### PR TITLE
Fix PW3 expansion role mapping in HA

### DIFF
--- a/custom_components/power_sync/__init__.py
+++ b/custom_components/power_sync/__init__.py
@@ -4667,6 +4667,7 @@ class BatteryHealthView(HomeAssistantView):
         from .powerwall_local.bms_health import (
             assign_pack_roles_from_battery_blocks,
             has_pw3_stack,
+            known_expansion_dins_from_gateway_config,
             reconcile_pack_remaining_with_aggregate,
             serial_from_din,
         )
@@ -4792,6 +4793,23 @@ class BatteryHealthView(HomeAssistantView):
                 _LOGGER.warning("fleet_api_bms: failed to extract text from response envelope")
                 return None
 
+        gateway_config = None
+        try:
+            runtime = self._hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+            local_runtime = runtime.get("powerwall_local") or {}
+            local_coordinator = local_runtime.get("coordinator")
+            local_snapshot = getattr(local_coordinator, "data", None)
+            raw_snapshot = getattr(local_snapshot, "raw", None)
+            if isinstance(raw_snapshot, dict) and isinstance(raw_snapshot.get("config"), dict):
+                gateway_config = raw_snapshot["config"]
+            else:
+                local_client = local_runtime.get("client") or getattr(local_coordinator, "client", None)
+                local_transport = getattr(local_client, "_transport", None)
+                if local_transport is not None:
+                    gateway_config = await local_transport.read_config(din)
+        except Exception as err:
+            _LOGGER.debug("fleet_api_bms: config.json read for expansion mapping failed: %s", err)
+
         # Primary source: control.systemStatus aggregate (matches cloud worker).
         # This is authoritative for the whole site — never override with partial per-pack sums.
         status = ((data.get("control") or {}).get("systemStatus") or {})
@@ -4889,6 +4907,7 @@ class BatteryHealthView(HomeAssistantView):
             battery_blocks,
             din,
             all_comps,
+            known_expansion_dins_from_gateway_config(gateway_config),
         )
 
         # Ghost expansion pack filter. Phantom packs (registered slots not physically

--- a/custom_components/power_sync/powerwall_local/bms_health.py
+++ b/custom_components/power_sync/powerwall_local/bms_health.py
@@ -29,8 +29,73 @@ def _block_din(block: dict[str, Any]) -> str | None:
     return din if isinstance(din, str) and din else None
 
 
+def known_expansion_dins_from_gateway_config(config: dict[str, Any] | None) -> list[str]:
+    """Return configured battery expansion DIN/VIN values from config.json."""
+    blocks = (config or {}).get("battery_blocks") or []
+    if not isinstance(blocks, list):
+        return []
+
+    dins: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        expansions = block.get("battery_expansions") or []
+        if not isinstance(expansions, list):
+            continue
+        for expansion in expansions:
+            if not isinstance(expansion, dict):
+                continue
+            din = expansion.get("din") or expansion.get("vin")
+            if isinstance(din, str) and din:
+                dins.append(din)
+    return dins
+
+
 def _is_pw3_din(din: Any) -> bool:
     return isinstance(din, str) and din.startswith("1707000-30-")
+
+
+def _expansion_dins_by_serial(known_expansion_dins: list[str] | None) -> dict[str, str]:
+    by_serial: dict[str, str] = {}
+    for din in known_expansion_dins or []:
+        serial = serial_from_din(din)
+        if serial:
+            by_serial[serial] = din
+    return by_serial
+
+
+def _pack_bms_serial(pack: dict[str, Any]) -> str | None:
+    serial = pack.get("bmsSerialNumber") or pack.get("bms_serial_number") or pack.get("serialNumber")
+    return serial if isinstance(serial, str) and serial else None
+
+
+def _choose_follower_indices(
+    packs: list[dict[str, Any]],
+    follower_slots_to_assign: int,
+    known_expansion_by_serial: dict[str, str],
+) -> set[int]:
+    if follower_slots_to_assign <= 0:
+        return set()
+
+    candidates = [
+        idx
+        for idx, pack in enumerate(packs)
+        if idx > 0
+        and not pack.get("isFollower")
+        and (
+            not (serial := _pack_bms_serial(pack))
+            or serial not in known_expansion_by_serial
+        )
+    ]
+    no_serial_candidates = [
+        idx for idx in candidates if not _pack_bms_serial(packs[idx])
+    ]
+    pool = (
+        no_serial_candidates
+        if len(no_serial_candidates) >= follower_slots_to_assign
+        else candidates
+    )
+    return set(pool[-follower_slots_to_assign:])
 
 
 def has_pw3_stack(
@@ -55,6 +120,7 @@ def assign_pack_roles_from_battery_blocks(
     battery_blocks: list[dict[str, Any]],
     leader_din: Any = None,
     components: list[dict[str, Any]] | None = None,
+    known_expansion_dins: list[str] | None = None,
 ) -> bool:
     """Normalise per-pack roles and physical serials from Tesla batteryBlocks.
 
@@ -89,19 +155,18 @@ def assign_pack_roles_from_battery_blocks(
     follower_dins = [din for din in base_dins if din != leader_physical_din]
     explicit_follower_count = sum(1 for pack in packs if pack.get("isFollower"))
     follower_slots_to_assign = max(0, len(follower_dins) - explicit_follower_count)
-    tail_follower_indices: set[int] = set()
-    if follower_slots_to_assign:
-        candidates = [
-            idx for idx, pack in enumerate(packs)
-            if idx > 0 and not pack.get("isFollower")
-        ]
-        tail_follower_indices = set(candidates[-follower_slots_to_assign:])
+    known_expansion_by_serial = _expansion_dins_by_serial(known_expansion_dins)
+    follower_indices = _choose_follower_indices(
+        packs,
+        follower_slots_to_assign,
+        known_expansion_by_serial,
+    )
 
     follower_seq = 0
     for idx, pack in enumerate(packs):
         if idx == 0:
             role = "leader"
-        elif pack.get("isFollower") or idx in tail_follower_indices:
+        elif pack.get("isFollower") or idx in follower_indices:
             role = "follower"
         else:
             role = "expansion"
@@ -118,7 +183,9 @@ def assign_pack_roles_from_battery_blocks(
             pack["physicalDin"] = physical_din
             pack["serialNumber"] = serial_from_din(physical_din) or pack.get("serialNumber")
         else:
-            pack["physicalDin"] = None
+            expansion_din = known_expansion_by_serial.get(_pack_bms_serial(pack) or "")
+            pack["physicalDin"] = expansion_din
+            pack["serialNumber"] = serial_from_din(expansion_din) or pack.get("serialNumber")
 
     return True
 

--- a/tests/test_powerwall_bms_health.py
+++ b/tests/test_powerwall_bms_health.py
@@ -23,6 +23,9 @@ reconcile_pack_remaining_with_aggregate = (
 assign_pack_roles_from_battery_blocks = (
     bms_health.assign_pack_roles_from_battery_blocks
 )
+known_expansion_dins_from_gateway_config = (
+    bms_health.known_expansion_dins_from_gateway_config
+)
 
 
 def test_reconciles_serial_less_near_empty_expansion_from_aggregate_remaining():
@@ -147,6 +150,87 @@ def test_assigns_pw3_leader_expansions_and_tail_follower_from_battery_blocks():
     assert packs[3]["serialNumber"] == "TG1253090007N5"
     assert packs[3]["physicalDin"] == "1707000-30-L--TG1253090007N5"
     assert packs[1]["serialNumber"] == "TG1252140009TS"
+
+
+def test_assigns_pw3_interleaved_config_expansion_before_followers():
+    packs = [
+        {"serialNumber": "TG124304001STC", "bmsSerialNumber": "TG124304001STC", "isFollower": False},
+        {"serialNumber": "TG125214001188", "bmsSerialNumber": "TG125214001188", "isFollower": False},
+        {"serialNumber": None, "bmsSerialNumber": None, "isFollower": False},
+        {"serialNumber": None, "bmsSerialNumber": None, "isFollower": False},
+    ]
+    battery_blocks = [
+        {"din": "1707000-30-K--TG1243040015ND"},
+        {"din": "1707000-30-L--TG1251520030PH"},
+        {"din": "1707000-30-L--TG125152001WC8"},
+    ]
+    gateway_config = {
+        "battery_blocks": [
+            {
+                "vin": "1707000-30-K--TG1243040015ND",
+                "battery_expansions": [
+                    {"din": "1807000-20-B--TG125214001188"},
+                ],
+            },
+            {"vin": "1707000-30-L--TG1251520030PH"},
+            {"vin": "1707000-30-L--TG125152001WC8"},
+        ]
+    }
+    components = [{"partNumber": "1707000-30-K", "serialNumber": "TG1243040015ND"}]
+
+    is_pw3 = assign_pack_roles_from_battery_blocks(
+        packs,
+        battery_blocks,
+        "1707000-30-K--TG1243040015ND",
+        components,
+        known_expansion_dins_from_gateway_config(gateway_config),
+    )
+
+    assert is_pw3 is True
+    assert [pack["role"] for pack in packs] == [
+        "leader",
+        "expansion",
+        "follower",
+        "follower",
+    ]
+    assert packs[1]["physicalDin"] == "1807000-20-B--TG125214001188"
+    assert packs[1]["serialNumber"] == "TG125214001188"
+    assert packs[2]["physicalDin"] == "1707000-30-L--TG1251520030PH"
+    assert packs[3]["physicalDin"] == "1707000-30-L--TG125152001WC8"
+
+
+def test_assigns_pw3_known_expansion_tail_slot_not_as_follower():
+    packs = [
+        {"serialNumber": "TG124304001STC", "bmsSerialNumber": "TG124304001STC", "isFollower": False},
+        {"serialNumber": None, "bmsSerialNumber": None, "isFollower": False},
+        {"serialNumber": None, "bmsSerialNumber": None, "isFollower": False},
+        {"serialNumber": "TG125214001188", "bmsSerialNumber": "TG125214001188", "isFollower": False},
+    ]
+    battery_blocks = [
+        {"din": "1707000-30-K--TG1243040015ND"},
+        {"din": "1707000-30-L--TG1251520030PH"},
+        {"din": "1707000-30-L--TG125152001WC8"},
+    ]
+    components = [{"partNumber": "1707000-30-K", "serialNumber": "TG1243040015ND"}]
+
+    is_pw3 = assign_pack_roles_from_battery_blocks(
+        packs,
+        battery_blocks,
+        "1707000-30-K--TG1243040015ND",
+        components,
+        ["1807000-20-B--TG125214001188"],
+    )
+
+    assert is_pw3 is True
+    assert [pack["role"] for pack in packs] == [
+        "leader",
+        "follower",
+        "follower",
+        "expansion",
+    ]
+    assert packs[3]["physicalDin"] == "1807000-20-B--TG125214001188"
+    assert packs[1]["physicalDin"] == "1707000-30-L--TG1251520030PH"
+    assert packs[2]["physicalDin"] == "1707000-30-L--TG125152001WC8"
 
 
 def test_keeps_four_pw2_packs_as_plain_powerwalls():


### PR DESCRIPTION
## Summary

Fix Home Assistant PW3 BMS role mapping so configured expansion packs are not misclassified as follower Powerwalls when Tesla interleaves component slots.

This mirrors the cloud/admin and v1r fixes:

- extracts configured expansion DIN/VIN values from gateway `config.json`
- matches known expansion DINs to BMS pack serials
- protects matched expansion rows before assigning follower slots
- preserves existing fallback behavior when config expansion DINs are unavailable
- carries the expansion physical DIN into per-pack attributes when matched
- reads cached/local `config.json` in the HA battery-health DCQ path for expansion mapping context

## Validation

- `pytest tests/test_powerwall_bms_health.py`
- `pytest tests/test_currency_sensor_metadata.py tests/test_powerwall_local_dcq_snapshot.py`
- `python3 -m py_compile custom_components/power_sync/powerwall_local/bms_health.py custom_components/power_sync/__init__.py`
