### PR TITLE
fix(logging): stop forcing DEBUG level on import

### DIFF
--- a/custom_components/power_sync/__init__.py
+++ b/custom_components/power_sync/__init__.py
@@ -1511,17 +1511,6 @@ def _get_neovolt_entry_ids(
             _LOGGER.debug("Could not expand legacy Neovolt config entry ids", exc_info=True)
     return [legacy_entry_id] if legacy_entry_id else []
 
-# Force DEBUG logging for power_sync and all submodules
-_LOGGER.setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.coordinator").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.sensor").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.inverters").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.inverters.sungrow").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.inverters.zeversolar").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.inverters.sigenergy").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.websocket_client").setLevel(logging.DEBUG)
-logging.getLogger("custom_components.power_sync.tariff_converter").setLevel(logging.DEBUG)
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,


### PR DESCRIPTION
## Problem
`custom_components/power_sync/__init__.py` unconditionally raises every PowerSync logger to DEBUG at import:

```python
_LOGGER.setLevel(logging.DEBUG)
logging.getLogger("custom_components.power_sync").setLevel(logging.DEBUG)
logging.getLogger("custom_components.power_sync.coordinator").setLevel(logging.DEBUG)
# ... 7 more submodule loggers
```

Because each submodule logger is given an **explicit** level, this overrides the user's Home Assistant `logger:` configuration and can't be lowered from YAML (a child logger with an explicit level ignores the parent). The result is heavy DEBUG output, formatted and emitted on the event-loop thread every cycle, regardless of the user's logging settings — avoidable overhead on busy systems.

## Fix
Remove the forced `setLevel` block so logging is governed by HA's `logger:` config as usual. (`inverters/sungrow.py` already sets `pymodbus` to `WARNING`, so intentional per-logger control is preserved.)

Found while debugging high event-loop load on a large install; users can then quiet the integration via standard `logger:` config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)