### PR TITLE
fix(coordinator): skip load-estimator cache invalidation when settings unchanged

### DIFF
--- a/custom_components/power_sync/optimization/coordinator.py
+++ b/custom_components/power_sync/optimization/coordinator.py
@@ -696,6 +696,12 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def set_spread_export_enabled(self, enabled: bool) -> None:
         """Enable or disable spread-export mode."""
+        # No-op when unchanged: a redundant settings push (e.g. the periodic
+        # settings sync from the companion app) must not invalidate the
+        # load-estimator cache, which forces an expensive temperature-sensitivity
+        # refit over the full load history on the event loop.
+        if self._config.spread_export_enabled == bool(enabled):
+            return
         self._config.spread_export_enabled = bool(enabled)
         if self._load_estimator:
             self._load_estimator.invalidate_cache()
@@ -722,6 +728,9 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def set_spread_import_enabled(self, enabled: bool) -> None:
         """Enable or disable spread-import mode."""
+        # No-op when unchanged (see set_spread_export_enabled).
+        if self._config.spread_import_enabled == bool(enabled):
+            return
         self._config.spread_import_enabled = bool(enabled)
         if self._load_estimator:
             self._load_estimator.invalidate_cache()
@@ -748,6 +757,10 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def set_profit_max_mode(self, enabled: bool) -> None:
         """Enable or disable profit maximisation mode."""
+        # No-op when unchanged (see set_spread_export_enabled) — avoids a
+        # redundant cache invalidation + load-estimator refit on every sync.
+        if self._config.profit_max_enabled == bool(enabled):
+            return
         self._config.profit_max_enabled = enabled
         if self._optimizer:
             self._optimizer.terminal_weight = self._profit_max_terminal_weight()
@@ -7911,16 +7924,25 @@ class OptimizationCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Handle profit maximisation mode toggle
         if "profit_max_enabled" in settings:
-            self.set_profit_max_mode(bool(settings["profit_max_enabled"]))
-            response["changes"].append(f"profit_max_enabled: {settings['profit_max_enabled']}")
+            new_val = bool(settings["profit_max_enabled"])
+            changed = self._config.profit_max_enabled != new_val
+            self.set_profit_max_mode(new_val)
+            if changed:
+                response["changes"].append(f"profit_max_enabled: {settings['profit_max_enabled']}")
 
         if "spread_export_enabled" in settings:
-            self.set_spread_export_enabled(bool(settings["spread_export_enabled"]))
-            response["changes"].append(f"spread_export_enabled: {settings['spread_export_enabled']}")
+            new_val = bool(settings["spread_export_enabled"])
+            changed = self._config.spread_export_enabled != new_val
+            self.set_spread_export_enabled(new_val)
+            if changed:
+                response["changes"].append(f"spread_export_enabled: {settings['spread_export_enabled']}")
 
         if "spread_import_enabled" in settings:
-            self.set_spread_import_enabled(bool(settings["spread_import_enabled"]))
-            response["changes"].append(f"spread_import_enabled: {settings['spread_import_enabled']}")
+            new_val = bool(settings["spread_import_enabled"])
+            changed = self._config.spread_import_enabled != new_val
+            self.set_spread_import_enabled(new_val)
+            if changed:
+                response["changes"].append(f"spread_import_enabled: {settings['spread_import_enabled']}")
 
         if "profit_max_target_time" in settings and self._entry:
             from ..const import CONF_PROFIT_MAX_TARGET_TIME


### PR DESCRIPTION
## Problem
On a large recorder history the HA frontend periodically froze. Traced to the load-estimator **temperature-sensitivity fit** (an O(N) pass over the full load history) being re-run far more often than its 1-hour cache should allow.

**Root cause:** `set_profit_max_mode`, `set_spread_export_enabled`, and `set_spread_import_enabled` call `self._load_estimator.invalidate_cache()` **unconditionally**. `set_settings()` re-applies all three on every push, so a periodic settings sync with **identical values** blows the α cache every cycle → forces the full refit → avoidable CPU/event-loop load (and the heavy fit was on the loop until v2.12.562 moved it to the executor). It also re-persisted the config entry and re-dispatched signals needlessly.

## Fix
- Guard each setter to **no-op when the value is unchanged**, so redundant pushes don't invalidate the cache / re-persist / re-dispatch.
- Compare against `bool(enabled)` consistently across the three setters.
- Only append to `set_settings()`'s `response["changes"]` when the value actually changed, so no-op syncs don't report false changes to the API caller.

No behaviour change for genuine setting changes; only redundant re-applies become no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)