### PR TITLE
fix(sensor): exclude oversized forecast attribute from the recorder

### DIFF
--- a/custom_components/power_sync/sensor.py
+++ b/custom_components/power_sync/sensor.py
@@ -301,6 +301,24 @@ def _sungrow_ac_inverter_power_kw(entry: ConfigEntry, hass: HomeAssistant) -> fl
         return 0.0
 
 
+# Large rolling prediction arrays exposed as sensor attributes (≈48h @ 5min /
+# price-period series). They exceed Home Assistant's 16 KB per-state recorder
+# attribute cap and are regenerated each cycle (not history), so the recorder
+# is told to skip them via Entity._unrecorded_attributes while the scalar state
+# is still recorded. Keys cover the LP optimizer, Solcast and Amber forecast
+# sensors (different sensors use different key names for their array).
+_FORECAST_ARRAY_ATTRS = frozenset({
+    "forecast",
+    "forecast_values_kw",
+    "charge_values_kw",
+    "discharge_values_kw",
+    "power_values_kw",
+    "price_values",
+    "hourly_forecast",
+    "forecast_periods",
+})
+
+
 @dataclass
 class PowerSyncSensorEntityDescription(SensorEntityDescription):
     """Describes PowerSync sensor entity."""
@@ -2305,6 +2323,11 @@ def _cleanup_legacy_powerwall_pack_registry(hass: HomeAssistant, entry: ConfigEn
 class AmberPriceSensor(PowerSyncCurrencyMixin, CoordinatorEntity, RestoredNumericStateMixin, SensorEntity):
     """Sensor for Amber electricity prices."""
 
+    # The "forecast" attribute is a large rolling price-forecast array that
+    # exceeds the recorder's 16 KB per-state attribute cap and is not history.
+    # Keep the scalar state recorded but exclude the bulky attribute.
+    _unrecorded_attributes = _FORECAST_ARRAY_ATTRS
+
     entity_description: PowerSyncSensorEntityDescription
 
     def __init__(
@@ -3183,6 +3206,13 @@ class SavingSessionSensor(CoordinatorEntity, SensorEntity):
 class SolcastForecastSensor(CoordinatorEntity, SensorEntity):
     """Sensor for Solcast solar production forecasts."""
 
+    # The "forecast" attribute is a large rolling prediction array (≈48h @ 5min)
+    # that exceeds the recorder's 16 KB per-state attribute cap and is not
+    # history (it's regenerated each cycle). Keep the scalar state recorded but
+    # exclude the bulky attribute so the recorder doesn't drop it with a warning
+    # or bloat the database.
+    _unrecorded_attributes = _FORECAST_ARRAY_ATTRS
+
     entity_description: PowerSyncSensorEntityDescription
 
     def __init__(
@@ -3348,6 +3378,11 @@ class LPForecastSensor(PowerSyncCurrencyMixin, CoordinatorEntity, SensorEntity):
     Reads forecast data stored by the OptimizationCoordinator each
     optimization cycle via get_forecast_data().
     """
+
+    # The "forecast" attribute is a large rolling prediction array (≈48h @ 5min)
+    # that exceeds the recorder's 16 KB per-state attribute cap and is not
+    # history. Keep the scalar state recorded but exclude the bulky attribute.
+    _unrecorded_attributes = _FORECAST_ARRAY_ATTRS
 
     entity_description: PowerSyncSensorEntityDescription
 


### PR DESCRIPTION
## Problem
The LP optimizer / Solcast / Amber price sensors expose large rolling prediction arrays as state attributes (≈48 h @ 5-minute — measured ~**27 KB / ~576 points** on the EV SoC forecast sensor) under several keys: `forecast`, `forecast_values_kw`, `charge_values_kw`, `discharge_values_kw`, `power_values_kw`, `price_values`, `hourly_forecast`, `forecast_periods`.

These exceed Home Assistant's **16,384-byte** per-state recorder attribute cap (`MAX_STATE_ATTRS_BYTES`), so the recorder logs every cycle:

```
WARNING (Recorder) [...db_schema] State attributes for sensor.powersync_ev_* exceed maximum size of 16384 bytes. This can cause database performance issues; Attributes will not be stored
```

and drops the attribute. Where large attributes are stored, recording a ~27 KB blob every cycle bloats the database and slows history queries.

## Fix
The forecast is a prediction regenerated each cycle — it's **not history** and shouldn't be recorded. Declare the array keys via HA's `Entity._unrecorded_attributes` (a shared `_FORECAST_ARRAY_ATTRS` frozenset) on `LPForecastSensor`, `SolcastForecastSensor` and `AmberPriceSensor`. The recorder then skips the bulky attributes while **still recording the scalar state** (the actual SoC / price / power value used for history). No user-facing change to the live attributes; only what the recorder persists. No migration required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)