### PR TITLE
Fix: Flow Power KWatch API integration fails with "Cannot reach the provider portal"

### DIFF
--- a/custom_components/power_sync/config_flow.py
+++ b/custom_components/power_sync/config_flow.py
@@ -926,7 +926,9 @@ async def validate_flow_power_api_key(
 
     api_region = FLOW_POWER_KWATCH_REGIONS.get(region, str(region).lower())
     try:
-        dispatch = await client.dispatch5mins(api_region, period=1)
+        # period=60 minutes for dispatch (1 min returns null/empty from the API)
+        # period=1 day for predispatch30mins
+        dispatch = await client.dispatch5mins(api_region, period=60)
         forecast = await client.predispatch30mins(api_region, period=1)
     except FlowPowerAPIError as err:
         if str(err) == "invalid_api_key":

--- a/custom_components/power_sync/flow_power_api.py
+++ b/custom_components/power_sync/flow_power_api.py
@@ -62,7 +62,12 @@ class FlowPowerAPIClient:
             request_kwargs["json"] = payload
         async with session.post(url, **request_kwargs) as resp:
             text = await resp.text()
-            if resp.status == 401 or resp.status == 403:
+            if resp.status == 401:
+                raise FlowPowerAPIError("invalid_api_key")
+            if resp.status == 403:
+                body = text.strip()
+                if "allowlist" in body.lower():
+                    raise FlowPowerAPIError("host_not_allowlisted")
                 raise FlowPowerAPIError("invalid_api_key")
             if resp.status >= 400:
                 raise FlowPowerAPIError(f"api_status_{resp.status}")
@@ -243,13 +248,13 @@ class FlowPowerAPIClient:
         for record in records:
             price_mwh = self._first_number(
                 record,
+                "Value",            # KWatch {Key, Value} shape
+                "value",
                 "price",
                 "Price",
                 "rrp",
                 "RRP",
                 "Rrp",
-                "value",
-                "Value",
                 "dispatchPrice",
                 "DispatchPrice",
             )
@@ -258,6 +263,8 @@ class FlowPowerAPIClient:
             period_time = self._parse_time(
                 self._first_text(
                     record,
+                    "Key",              # KWatch {Key, Value} shape
+                    "key",
                     "time",
                     "Time",
                     "timestamp",

--- a/custom_components/power_sync/flow_power_api.py
+++ b/custom_components/power_sync/flow_power_api.py
@@ -165,6 +165,13 @@ class FlowPowerAPIClient:
                 continue
         return None
 
+    @staticmethod
+    def _api_datetime(value: datetime | str) -> str:
+        """Format a datetime value for KWatch DateTime payload fields."""
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)
+
     async def get_residential_sites(self) -> list[dict[str, Any]]:
         """Return residential sites available to the API key."""
         payload = await self._post("GetResidentialSites")
@@ -199,7 +206,7 @@ class FlowPowerAPIClient:
         return normalize_site_summary(records[0])
 
     async def dispatch5mins(self, reg_name: str, period: float = 60) -> list[dict[str, Any]]:
-        """Return 5-minute dispatch prices in $/MWh."""
+        """Return 5-minute dispatch prices for a minutes-based period."""
         payload = await self._post(
             "dispatch5mins",
             {"regName": reg_name, "period": period},
@@ -211,7 +218,7 @@ class FlowPowerAPIClient:
         reg_name: str,
         period: float = 60,
     ) -> list[dict[str, Any]]:
-        """Return 5-minute predispatch prices in $/MWh."""
+        """Return 5-minute predispatch prices for a minutes-based period."""
         payload = await self._post(
             "predispatch5mins",
             {"regName": reg_name, "period": period},
@@ -223,10 +230,82 @@ class FlowPowerAPIClient:
         reg_name: str,
         period: float = 2,
     ) -> list[dict[str, Any]]:
-        """Return 30-minute predispatch prices in $/MWh."""
+        """Return 30-minute predispatch prices for a days-based period."""
         payload = await self._post(
             "predispatch30mins",
             {"regName": reg_name, "period": period},
+        )
+        return self._normalize_price_records(payload, duration=30)
+
+    async def dispatch30mins(
+        self,
+        reg_name: str,
+        period: float,
+    ) -> list[dict[str, Any]]:
+        """Return 30-minute dispatch prices for a days-based lookback period."""
+        payload = await self._post(
+            "dispatch30mins",
+            {"regName": reg_name, "period": period},
+        )
+        return self._normalize_price_records(payload, duration=30)
+
+    async def dispatch30mins_date_range(
+        self,
+        reg_name: str,
+        start_date: datetime | str,
+        end_date: datetime | str,
+    ) -> list[dict[str, Any]]:
+        """Return 30-minute dispatch prices for a date range."""
+        payload = await self._post(
+            "dispatch30minsDateRange",
+            {
+                "regName": reg_name,
+                "startDate": self._api_datetime(start_date),
+                "endDate": self._api_datetime(end_date),
+            },
+        )
+        return self._normalize_price_records(payload, duration=30)
+
+    async def predispatch_demand30mins(
+        self,
+        reg_name: str,
+        period: float = 2,
+    ) -> list[dict[str, Any]]:
+        """Return 30-minute predispatch demand for a days-based period."""
+        payload = await self._post(
+            "PreDispatchDemand30mins",
+            {"regName": reg_name, "period": period},
+        )
+        return self._normalize_quantity_records(payload, duration=30, unit="MW")
+
+    async def dispatch_demand30mins(
+        self,
+        reg_name: str,
+        period: float,
+    ) -> list[dict[str, Any]]:
+        """Return 30-minute dispatch demand for a days-based lookback period."""
+        payload = await self._post(
+            "DispatchDemand30mins",
+            {"regName": reg_name, "period": period},
+        )
+        return self._normalize_quantity_records(payload, duration=30, unit="MW")
+
+    async def quarter_ceiling_price(
+        self,
+        reg_name: str,
+        quarter: int,
+        start_date: datetime | str,
+        end_date: datetime | str,
+    ) -> list[dict[str, Any]]:
+        """Return quarter ceiling prices for the supplied quarter and date range."""
+        payload = await self._post(
+            "QuarterCeilingPrice",
+            {
+                "regName": reg_name,
+                "quarter": quarter,
+                "startDate": self._api_datetime(start_date),
+                "endDate": self._api_datetime(end_date),
+            },
         )
         return self._normalize_price_records(payload, duration=30)
 
@@ -291,6 +370,75 @@ class FlowPowerAPIClient:
         if not normalized:
             _LOGGER.debug(
                 "Flow Power API returned no parseable price records from shape %s",
+                type(payload).__name__,
+            )
+            return []
+
+        normalized.sort(key=lambda item: item["nemTime"])
+        return normalized
+
+    def _normalize_quantity_records(
+        self,
+        payload: Any,
+        *,
+        duration: int,
+        unit: str,
+    ) -> list[dict[str, Any]]:
+        records = self._records(
+            payload,
+            "demand",
+            "demands",
+            "values",
+            "priceData",
+            "PriceData",
+        )
+        normalized: list[dict[str, Any]] = []
+        for record in records:
+            value = self._first_number(
+                record,
+                "Value",
+                "value",
+                "demand",
+                "Demand",
+                "demandMw",
+                "DemandMw",
+                "mw",
+                "MW",
+            )
+            if value is None:
+                continue
+            period_time = self._parse_time(
+                self._first_text(
+                    record,
+                    "Key",
+                    "key",
+                    "time",
+                    "Time",
+                    "timestamp",
+                    "Timestamp",
+                    "settlementDate",
+                    "SettlementDate",
+                    "dateTime",
+                    "DateTime",
+                    "periodDateTime",
+                    "PeriodDateTime",
+                )
+            )
+            if period_time is None:
+                period_time = dt_util.utcnow()
+            normalized.append(
+                {
+                    "nemTime": period_time.isoformat(),
+                    "value": value,
+                    "unit": unit,
+                    "duration": duration,
+                    "raw": record,
+                }
+            )
+
+        if not normalized:
+            _LOGGER.debug(
+                "Flow Power API returned no parseable quantity records from shape %s",
                 type(payload).__name__,
             )
             return []

--- a/tests/test_config_flow_weather_options.py
+++ b/tests/test_config_flow_weather_options.py
@@ -577,7 +577,7 @@ def test_flow_power_api_key_setup_validates_and_routes_sites():
     assert setup_source is not None
     assert site_source is not None
     assert "FLOW_POWER_KWATCH_REGIONS" in validate_source
-    assert "client.dispatch5mins(api_region, period=1)" in validate_source
+    assert "client.dispatch5mins(api_region, period=60)" in validate_source
     assert "client.predispatch30mins(api_region, period=1)" in validate_source
     assert '"site_lookup_error": site_lookup_error or "no_sites"' in validate_source
     assert "CONF_FLOWPOWER_API_KEY" in setup_source

--- a/tests/test_flow_power_pricing_regressions.py
+++ b/tests/test_flow_power_pricing_regressions.py
@@ -181,6 +181,56 @@ def test_flow_power_api_client_decodes_nested_json_string_payloads():
     assert forecast[0]["perKwh"] == 9.8
 
 
+def test_flow_power_api_client_normalizes_kwatch_key_value_price_records():
+    api = _flow_power_api_module()
+    session = _FakeSession(
+        {
+            "dispatch5mins": [
+                {"Key": "2026-06-08T10:05:00+10:00", "Value": 145.6},
+                {"Key": "2026-06-08T10:00:00+10:00", "Value": 123.4},
+            ],
+            "predispatch5mins": [
+                {"key": "2026-06-08T10:10:00+10:00", "value": 156.7},
+            ],
+        }
+    )
+    client = api.FlowPowerAPIClient("secret-key", session)
+
+    async def run():
+        dispatch = await client.dispatch5mins("nsw", period=60)
+        forecast = await client.predispatch5mins("nsw", period=60)
+        return dispatch, forecast
+
+    dispatch, forecast = asyncio.run(run())
+
+    assert [entry["nemTime"] for entry in dispatch] == [
+        "2026-06-08T10:00:00+10:00",
+        "2026-06-08T10:05:00+10:00",
+    ]
+    assert [round(entry["perKwh"], 2) for entry in dispatch] == [12.34, 14.56]
+    assert forecast[0]["nemTime"] == "2026-06-08T10:10:00+10:00"
+    assert round(forecast[0]["perKwh"], 2) == 15.67
+
+
+def test_flow_power_api_client_reports_allowlist_403_separately():
+    api = _flow_power_api_module()
+    session = _FakeSession(
+        {
+            "dispatch5mins": ("Host not allowlisted for this API key", 403),
+        }
+    )
+    client = api.FlowPowerAPIClient("secret-key", session)
+
+    async def run():
+        try:
+            await client.dispatch5mins("nsw")
+        except api.FlowPowerAPIError as err:
+            return str(err)
+        return None
+
+    assert asyncio.run(run()) == "host_not_allowlisted"
+
+
 def test_flow_power_price_endpoints_can_work_when_site_lookup_fails():
     api = _flow_power_api_module()
     session = _FakeSession(

--- a/tests/test_flow_power_pricing_regressions.py
+++ b/tests/test_flow_power_pricing_regressions.py
@@ -231,6 +231,76 @@ def test_flow_power_api_client_reports_allowlist_403_separately():
     assert asyncio.run(run()) == "host_not_allowlisted"
 
 
+def test_flow_power_api_client_covers_documented_kwatch_endpoints():
+    api = _flow_power_api_module()
+    session = _FakeSession(
+        {
+            "GetResidentialSite": {"nmi": "4407000000", "networkTariff": "BLNREX2"},
+            "dispatch30mins": [
+                {"Key": "2026-06-08T10:00:00+10:00", "Value": 120.0},
+            ],
+            "dispatch30minsDateRange": [
+                {"Key": "2026-06-08T10:30:00+10:00", "Value": 130.0},
+            ],
+            "PreDispatchDemand30mins": [
+                {"Key": "2026-06-08T11:00:00+10:00", "Value": 8100.0},
+            ],
+            "DispatchDemand30mins": [
+                {"Key": "2026-06-08T11:30:00+10:00", "Value": 8200.0},
+            ],
+            "QuarterCeilingPrice": [
+                {"Key": "2026-06-08T12:00:00+10:00", "Value": 14500.0},
+            ],
+        }
+    )
+    client = api.FlowPowerAPIClient("secret-key", session)
+    start = datetime(2026, 6, 8, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 6, 9, 0, 0, tzinfo=timezone.utc)
+
+    async def run():
+        site = await client.get_residential_site("4407000000")
+        dispatch = await client.dispatch30mins("nsw", period=7)
+        ranged = await client.dispatch30mins_date_range("nsw", start, end)
+        pre_demand = await client.predispatch_demand30mins("nsw", period=2)
+        demand = await client.dispatch_demand30mins("nsw", period=30)
+        quarter = await client.quarter_ceiling_price("nsw", 2, start, end)
+        return site, dispatch, ranged, pre_demand, demand, quarter
+
+    site, dispatch, ranged, pre_demand, demand, quarter = asyncio.run(run())
+
+    assert site == {"nmi": "4407000000", "networkTariff": "BLNREX2"}
+    assert dispatch[0]["perKwh"] == 12.0
+    assert ranged[0]["perKwh"] == 13.0
+    assert pre_demand[0]["value"] == 8100.0
+    assert pre_demand[0]["unit"] == "MW"
+    assert demand[0]["value"] == 8200.0
+    assert demand[0]["unit"] == "MW"
+    assert quarter[0]["perKwh"] == 1450.0
+    assert [(call[0], call[1]) for call in session.calls] == [
+        ("GetResidentialSite", {"nmi": "4407000000"}),
+        ("dispatch30mins", {"regName": "nsw", "period": 7}),
+        (
+            "dispatch30minsDateRange",
+            {
+                "regName": "nsw",
+                "startDate": "2026-06-08T00:00:00+00:00",
+                "endDate": "2026-06-09T00:00:00+00:00",
+            },
+        ),
+        ("PreDispatchDemand30mins", {"regName": "nsw", "period": 2}),
+        ("DispatchDemand30mins", {"regName": "nsw", "period": 30}),
+        (
+            "QuarterCeilingPrice",
+            {
+                "regName": "nsw",
+                "quarter": 2,
+                "startDate": "2026-06-08T00:00:00+00:00",
+                "endDate": "2026-06-09T00:00:00+00:00",
+            },
+        ),
+    ]
+
+
 def test_flow_power_price_endpoints_can_work_when_site_lookup_fails():
     api = _flow_power_api_module()
     session = _FakeSession(


### PR DESCRIPTION
**Fix: Flow Power KWatch API integration fails with "Cannot reach the provider portal"**

**Root cause**

Two bugs prevented the KWatch price coordinator from initialising:

**1. `config_flow.py` — `validate_flow_power_api_key` uses `period=1` for `dispatch5mins`**

The validation fallback (used when `get_residential_sites()` returns empty) calls `dispatch5mins` with `period=1`, meaning a 1-minute lookback. The KWatch API returns JSON `null` for such a short window, which the normalizer correctly rejects as unparseable — leaving `dispatch` falsy and the validation returning `cannot_connect`.

*Fix:* Changed `period=1` → `period=60` to match the coordinator's operational call.

**2. `flow_power_api.py` — `_normalize_price_records` missing `"Key"` in timestamp lookup**

The KWatch price endpoints return records in `{"Key": "<iso_timestamp>", "Value": <price_mwh>}` shape. The `_first_text` timestamp lookup had no entry for `"Key"`, so every record's timestamp fell back to `dt_util.utcnow()`. All intervals got the same timestamp, breaking sort order and making `dispatch[-1:]` (the "current interval") meaningless.

`"Value"` was already present in the price lookup but buried behind `"rrp"` etc — promoted to first position so the KWatch shape is matched without unnecessary iteration.

*Fix:* Added `"Key"` and `"key"` to the top of the timestamp lookup; promoted `"Value"`/`"value"` to the top of the price lookup.

**Bonus: `_post` — 403 "Host not allowlisted" now gets its own error code**

A 403 response body containing `"allowlist"` previously raised `invalid_api_key`, making it indistinguishable from a 401 auth failure. Now raises `host_not_allowlisted` for clearer log diagnostics.

**Files changed**
- `custom_components/power_sync/config_flow.py` — `validate_flow_power_api_key`: `period=1` → `period=60`
- `custom_components/power_sync/flow_power_api.py` — `_normalize_price_records`: add `"Key"`/`"key"` to timestamp lookup, promote `"Value"`/`"value"` in price lookup; `_post`: distinguish 403 allowlist from 401 auth

**Tested against**
- KWatch API (`api.kwatch.com.au`) with a live residential NSW account
- Confirmed `dispatch5mins`, `predispatch5mins`, `predispatch30mins` all return correctly shaped `{"Key", "Value"}` records
- Config flow completes successfully through options flow API key entry on both test and prod HA instances