### PR TITLE
fix(solaredge): select valid force-charge controls

### DIFF
--- a/custom_components/power_sync/inverters/solaredge.py
+++ b/custom_components/power_sync/inverters/solaredge.py
@@ -19,6 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 
 _UNAVAILABLE = {"", "unknown", "unavailable", "none", "None"}
 
+# Canonical suffixes come from solaredge-modbus-multi's select.py and number.py;
+# the remaining values support other SolarEdge entity naming conventions.
 _CONTROL_ENTITIES: dict[str, tuple[str, tuple[str, ...]]] = {
     "storage_control_mode": (
         "select",
@@ -305,7 +307,9 @@ class SolarEdgeController(InverterController):
     ) -> None:
         super().__init__(host, port, slave_id, model)
         self.rated_power_w = float(rated_power_w or self.DEFAULT_RATED_POWER_W)
-        self.entity_prefix = (entity_prefix or "").strip()
+        self.entity_prefix = (
+            (entity_prefix or "").strip().removesuffix("*").rstrip("_")
+        )
         self._hass = hass
         self._client = None
         self._lock = asyncio.Lock()
@@ -615,6 +619,9 @@ class SolarEdgeController(InverterController):
 class SolarEdgeEnergyController:
     """Bridge SolarEdge Home battery telemetry and control through HA entities."""
 
+    WRITE_CONFIRM_TIMEOUT_SECONDS = 3.0
+    WRITE_CONFIRM_INTERVAL_SECONDS = 0.25
+
     def __init__(
         self,
         hass: Any,
@@ -622,7 +629,7 @@ class SolarEdgeEnergyController:
         solaredge_entry_id: str | None = None,
     ) -> None:
         self.hass = hass
-        self._prefix = entity_prefix.strip()
+        self._prefix = entity_prefix.strip().removesuffix("*").rstrip("_")
         self._solaredge_entry_id = (solaredge_entry_id or "").strip()
         self._entity_map: dict[str, str] = {}
         self._control_entity_map: dict[str, str] = {}
@@ -880,6 +887,8 @@ class SolarEdgeEnergyController:
             )
             return False
 
+        # TODO: Preflight required select options here if partial dispatch
+        # becomes a problem on integrations that expose incomplete option lists.
         self._save_current_control_state()
         duration_seconds = max(60, int(duration_minutes) * 60)
         target_power = self._coerce_target_power("charge_power_limit" if command == "charge" else "discharge_power_limit", power_w)
@@ -889,7 +898,11 @@ class SolarEdgeEnergyController:
             ok &= await self._set_select_by_alias("storage_control_mode", _REMOTE_CONTROL_OPTIONS)
             ok &= await self._set_number_if_mapped("command_timeout", duration_seconds)
             if command == "charge":
-                ok &= await self._set_optional_grid_charge(True)
+                if not await self._set_optional_grid_charge(True):
+                    _LOGGER.warning(
+                        "SolarEdge AC charge policy write failed; continuing with "
+                        "the explicit storage grid-charge command"
+                    )
                 ok &= await self._set_number_if_mapped("discharge_power_limit", 0)
                 ok &= await self._set_number_if_mapped("charge_power_limit", target_power)
                 ok &= await self._set_select_by_alias("storage_command_mode", _CHARGE_OPTIONS)
@@ -940,12 +953,49 @@ class SolarEdgeEnergyController:
             entity_id = self._resolve_entity_id(entity_ids, "sensor", suffixes, legacy_prefix, key)
             if entity_id:
                 self._entity_map[key] = entity_id
+        # TODO: Add explicit inverter scoping here if generic prefixes need
+        # first-class support for installations with multiple inverters.
         for key, (domain, suffixes) in _CONTROL_ENTITIES.items():
-            entity_id = self._resolve_entity_id(entity_ids, domain, suffixes, legacy_prefix, key)
+            entity_id = self._resolve_control_entity_id(
+                entity_ids, domain, suffixes, legacy_prefix, key
+            )
             if not entity_id and key == "allow_grid_charge":
-                entity_id = self._resolve_entity_id(entity_ids, "select", suffixes, legacy_prefix, key)
+                entity_id = self._resolve_control_entity_id(
+                    entity_ids, "select", suffixes, legacy_prefix, key
+                )
             if entity_id:
                 self._control_entity_map[key] = entity_id
+
+    def _resolve_control_entity_id(
+        self,
+        entity_ids: list[str],
+        domain: str,
+        suffixes: tuple[str, ...],
+        prefix: str | None,
+        key: str,
+    ) -> str | None:
+        """Return the first usable control candidate in suffix order."""
+        for suffix in suffixes:
+            entity_id = self._resolve_entity_id(
+                entity_ids,
+                domain,
+                (suffix,),
+                prefix,
+                key,
+            )
+            if not entity_id:
+                continue
+            rejection = self._control_candidate_rejection(entity_id, key)
+            if rejection:
+                _LOGGER.debug(
+                    "SolarEdge rejected %s candidate %s: %s",
+                    key,
+                    entity_id,
+                    rejection,
+                )
+                continue
+            return entity_id
+        return None
 
     def _resolve_entity_id(
         self,
@@ -989,6 +1039,54 @@ class SolarEdgeEnergyController:
         if not valid_matches:
             return None
         return sorted(valid_matches, key=lambda entity_id: self._match_score(entity_id, key))[0]
+
+    def _control_candidate_rejection(self, entity_id: str, key: str) -> str | None:
+        """Return why a writable entity cannot safely fulfil a control role."""
+        if key not in _CONTROL_ENTITIES:
+            return None
+
+        state = self.hass.states.get(entity_id)
+        if state is None:
+            return "entity has no state"
+        if str(state.state) in _UNAVAILABLE:
+            return f"state is {state.state!r}"
+
+        domain = entity_id.split(".", 1)[0]
+        body = entity_id.split(".", 1)[-1].lower()
+        if key == "storage_control_mode":
+            if "_limit_control_mode" in body:
+                return "Limit Control Mode controls export or production, not storage"
+            options = (getattr(state, "attributes", {}) or {}).get("options") or []
+            recognised = {
+                _normalize_option(alias)
+                for alias in (*_REMOTE_CONTROL_OPTIONS, *_SELF_USE_OPTIONS)
+            }
+            if not any(
+                _normalize_option(str(option)) in recognised for option in options
+            ):
+                return "selector has no recognised storage-control options"
+
+        if domain == "number" and key in {
+            "charge_power_limit",
+            "discharge_power_limit",
+        }:
+            attrs = getattr(state, "attributes", {}) or {}
+            try:
+                minimum = float(attrs.get("min", attrs.get("native_min_value", 0)))
+                maximum_value = attrs.get("max", attrs.get("native_max_value"))
+                maximum = (
+                    float(maximum_value) if maximum_value is not None else None
+                )
+            except (TypeError, ValueError):
+                return "numeric range is invalid"
+            if not math.isfinite(minimum) or (
+                maximum is not None and not math.isfinite(maximum)
+            ):
+                return "numeric range is not finite"
+            if maximum is not None and (maximum == 0 or maximum <= minimum):
+                return f"numeric range is unusable ({minimum} to {maximum})"
+
+        return None
 
     @staticmethod
     def _is_non_solar_power_entity(entity_id: str) -> bool:
@@ -1093,6 +1191,14 @@ class SolarEdgeEnergyController:
             )
             return True
         except Exception as err:
+            if await self._wait_for_reflected_state(entity_id, numeric):
+                _LOGGER.warning(
+                    "SolarEdge number write for %s raised %s, but the requested "
+                    "state was subsequently reflected",
+                    entity_id,
+                    err,
+                )
+                return True
             _LOGGER.error("SolarEdge number write failed for %s: %s", entity_id, err)
             return False
 
@@ -1146,6 +1252,15 @@ class SolarEdgeEnergyController:
             )
             return True
         except Exception as err:
+            if await self._wait_for_reflected_state(entity_id, option):
+                _LOGGER.warning(
+                    "SolarEdge select write for %s=%s raised %s, but the requested "
+                    "state was subsequently reflected",
+                    entity_id,
+                    option,
+                    err,
+                )
+                return True
             _LOGGER.error("SolarEdge select write failed for %s=%s: %s", entity_id, option, err)
             return False
 
@@ -1183,6 +1298,39 @@ class SolarEdgeEnergyController:
         except Exception as err:
             _LOGGER.error("SolarEdge switch write failed for %s: %s", entity_id, err)
             return False
+
+    async def _wait_for_reflected_state(
+        self,
+        entity_id: str,
+        expected: Any,
+    ) -> bool:
+        """Confirm an ambiguous service-call outcome from the HA state machine."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.WRITE_CONFIRM_TIMEOUT_SECONDS
+        while True:
+            state = self.hass.states.get(entity_id)
+            current = getattr(state, "state", None)
+            if self._control_values_match(entity_id, current, expected):
+                return True
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(self.WRITE_CONFIRM_INTERVAL_SECONDS, remaining))
+
+    @staticmethod
+    def _control_values_match(
+        entity_id: str,
+        current: Any,
+        expected: Any,
+    ) -> bool:
+        if current is None or str(current) in _UNAVAILABLE:
+            return False
+        if entity_id.startswith("number."):
+            try:
+                return math.isclose(float(current), float(expected))
+            except (TypeError, ValueError):
+                return False
+        return _normalize_option(str(current)) == _normalize_option(str(expected))
 
     def _expected_entity_hint(self, key: str) -> str:
         suffixes = _ENERGY_READ_ENTITIES.get(key) or ()

--- a/tests/test_solaredge_controller.py
+++ b/tests/test_solaredge_controller.py
@@ -57,7 +57,8 @@ def test_solaredge_zero_curtail_and_restore_write_percent_limits():
     assert writes == [0, 100]
 
 
-def test_solaredge_entity_fallback_prefers_configured_prefix():
+@pytest.mark.parametrize("entity_prefix", ["custom", "custom_*"])
+def test_solaredge_entity_fallback_prefers_configured_prefix(entity_prefix: str):
     class State:
         def __init__(self, state: str) -> None:
             self.state = state
@@ -87,7 +88,7 @@ def test_solaredge_entity_fallback_prefers_configured_prefix():
     hass = Hass()
     controller = SolarEdgeController(
         host="",
-        entity_prefix="custom",
+        entity_prefix=entity_prefix,
         hass=hass,
     )
 
@@ -427,6 +428,40 @@ class _SEServices:
             state.state = "on" if service == "turn_on" else "off"
 
 
+class _SEFailingServices(_SEServices):
+    def __init__(
+        self,
+        states: _SEStates,
+        failing_entity_id: str,
+        reflect_delay: float | None = None,
+    ) -> None:
+        super().__init__(states)
+        self._failing_entity_id = failing_entity_id
+        self._reflect_delay = reflect_delay
+
+    async def async_call(
+        self,
+        domain: str,
+        service: str,
+        data: dict,
+        blocking: bool = False,
+    ):
+        if data.get("entity_id") != self._failing_entity_id:
+            return await super().async_call(domain, service, data, blocking)
+        self.calls.append((domain, service, data))
+        if self._reflect_delay is not None:
+            async def reflect_state():
+                await asyncio.sleep(self._reflect_delay)
+                state = self._states.get(self._failing_entity_id)
+                if state and domain == "select":
+                    state.state = str(data["option"])
+                elif state and domain == "number":
+                    state.state = str(data["value"])
+
+            asyncio.create_task(reflect_state())
+        raise TimeoutError("service call timed out")
+
+
 class _SEHass:
     def __init__(self, include_control: bool = True) -> None:
         states = {
@@ -498,6 +533,128 @@ def test_solaredge_energy_bridge_discovers_control_entities():
         "number.solaredge_backup_reserve"
     )
     assert controller.get_status()["telemetry_ready"] is True
+
+
+def test_solaredge_control_discovery_prefers_valid_storage_entities():
+    hass = _SEHass()
+    hass.states._states.update(
+        {
+            "select.solaredge_i1_storage_control_mode": _SEState(
+                "select.solaredge_i1_storage_control_mode",
+                "Maximize Self Consumption",
+                {"options": ["Maximize Self Consumption", "Remote Control"]},
+            ),
+            "select.solaredge_i1_limit_control_mode": _SEState(
+                "select.solaredge_i1_limit_control_mode",
+                "Export Control",
+                {"options": ["Export Control", "Production Control"]},
+            ),
+            "number.solaredge_i1_storage_charge_limit": _SEState(
+                "number.solaredge_i1_storage_charge_limit",
+                "11400",
+                {"unit_of_measurement": "W", "min": 0, "max": 11400},
+            ),
+            "number.solaredge_i1_ac_charge_limit": _SEState(
+                "number.solaredge_i1_ac_charge_limit",
+                "unavailable",
+                {"unit_of_measurement": "W", "min": 0, "max": 0},
+            ),
+        }
+    )
+    hass.states._states.pop("select.solaredge_storage_control_mode")
+    hass.states._states.pop("number.solaredge_storage_charge_limit")
+    for entity_id in list(hass.states._states):
+        if entity_id.startswith(
+            ("select.solaredge_", "number.solaredge_", "switch.solaredge_")
+        ) and "_i1_" not in entity_id:
+            state = hass.states._states.pop(entity_id)
+            state.entity_id = entity_id.replace("solaredge_", "solaredge_i1_", 1)
+            hass.states._states[state.entity_id] = state
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert controller._control_entity_map["storage_control_mode"] == (
+        "select.solaredge_i1_storage_control_mode"
+    )
+    assert controller._control_entity_map["charge_power_limit"] == (
+        "number.solaredge_i1_storage_charge_limit"
+    )
+    assert asyncio.run(controller.force_charge(duration_minutes=30, power_w=4200))
+    called_entities = {call[2]["entity_id"] for call in hass.services.calls}
+    assert "select.solaredge_i1_storage_control_mode" in called_entities
+    assert "number.solaredge_i1_storage_charge_limit" in called_entities
+    assert "select.solaredge_i1_limit_control_mode" not in called_entities
+    assert "number.solaredge_i1_ac_charge_limit" not in called_entities
+
+
+def test_solaredge_control_discovery_accepts_trailing_wildcard_prefix():
+    hass = _SEHass()
+    for entity_id in list(hass.states._states):
+        if entity_id.startswith(("select.solaredge_", "number.solaredge_", "switch.solaredge_")):
+            state = hass.states._states.pop(entity_id)
+            state.entity_id = entity_id.replace("solaredge_", "solaredge_i1_", 1)
+            hass.states._states[state.entity_id] = state
+
+    controller = SolarEdgeEnergyController(
+        hass,
+        entity_prefix="solaredge_i1_*",
+    )
+
+    assert asyncio.run(controller.connect())
+    assert controller.control_available()
+    assert controller._control_entity_map["storage_control_mode"] == (
+        "select.solaredge_i1_storage_control_mode"
+    )
+    assert controller._control_entity_map["charge_power_limit"] == (
+        "number.solaredge_i1_storage_charge_limit"
+    )
+
+
+def test_solaredge_control_discovery_rejects_limit_control_mode():
+    hass = _SEHass()
+    hass.states._states.pop("select.solaredge_storage_control_mode")
+    hass.states._states["select.solaredge_i1_limit_control_mode"] = _SEState(
+        "select.solaredge_i1_limit_control_mode",
+        "Export Control",
+        {"options": ["Export Control", "Production Control"]},
+    )
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert "storage_control_mode" not in controller._control_entity_map
+    assert "storage_control_mode" in controller.missing_control_entities()
+
+
+def test_solaredge_control_discovery_continues_after_unavailable_candidate():
+    hass = _SEHass()
+    hass.states.get("number.solaredge_storage_charge_limit").state = "unavailable"
+    hass.states._states["number.solaredge_battery_charge_power_limit"] = _SEState(
+        "number.solaredge_battery_charge_power_limit",
+        "0",
+        {"min": 0, "max": 6000},
+    )
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert controller._control_entity_map["charge_power_limit"] == (
+        "number.solaredge_battery_charge_power_limit"
+    )
+
+
+def test_solaredge_control_discovery_keeps_usable_ac_charge_limit_fallback():
+    hass = _SEHass()
+    hass.states._states.pop("number.solaredge_storage_charge_limit")
+    hass.states._states["number.solaredge_ac_charge_limit"] = _SEState(
+        "number.solaredge_ac_charge_limit",
+        "0",
+        {"min": 0, "max": 6000},
+    )
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert controller._control_entity_map["charge_power_limit"] == (
+        "number.solaredge_ac_charge_limit"
+    )
 
 
 def test_solaredge_startup_readiness_rejects_unavailable_and_accepts_zeroes():
@@ -615,6 +772,64 @@ def test_solaredge_force_charge_uses_grid_command_and_ac_policy_entities(
     assert hass.states.get("select.solaredge_storage_command_mode").state == (
         "Solar Power Only (Off)"
     )
+
+
+def test_solaredge_force_charge_does_not_rollback_when_ac_policy_fails():
+    hass = _SEHass()
+    command_mode = hass.states.get("select.solaredge_storage_command_mode")
+    command_mode.state = "Maximize Self Consumption"
+    command_mode.attributes["options"] = [
+        "Charge from Clipped Solar Power",
+        "Charge from Solar Power and Grid",
+        "Maximize Self Consumption",
+    ]
+    hass.states._states.pop("switch.solaredge_allow_grid_charge")
+    policy_entity_id = "select.solaredge_i1_ac_charge_policy"
+    hass.states._states[policy_entity_id] = _SEState(
+        policy_entity_id,
+        "Disabled",
+        {"options": ["Disabled", "Always Allowed"]},
+    )
+    hass.services = _SEFailingServices(hass.states, policy_entity_id)
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+    controller.WRITE_CONFIRM_TIMEOUT_SECONDS = 0
+
+    assert asyncio.run(controller.connect())
+    assert asyncio.run(controller.force_charge(duration_minutes=30, power_w=4200))
+    assert hass.states.get(policy_entity_id).state == "Disabled"
+    assert hass.states.get("select.solaredge_storage_command_mode").state == (
+        "Charge from Solar Power and Grid"
+    )
+
+
+def test_solaredge_force_charge_accepts_timeout_when_state_is_reflected():
+    hass = _SEHass()
+    command_entity_id = "select.solaredge_storage_command_mode"
+    hass.services = _SEFailingServices(
+        hass.states,
+        command_entity_id,
+        reflect_delay=0.01,
+    )
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert asyncio.run(controller.force_charge(duration_minutes=30, power_w=4200))
+    assert hass.states.get(command_entity_id).state == "Charge"
+
+
+def test_solaredge_force_charge_accepts_number_timeout_when_state_is_reflected():
+    hass = _SEHass()
+    timeout_entity_id = "number.solaredge_storage_command_timeout"
+    hass.services = _SEFailingServices(
+        hass.states,
+        timeout_entity_id,
+        reflect_delay=0.01,
+    )
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert asyncio.run(controller.force_charge(duration_minutes=30, power_w=4200))
+    assert hass.states.get(timeout_entity_id).state == "1800.0"
 
 
 def test_solaredge_stale_dispatch_restore_preserves_saved_ac_policy():


### PR DESCRIPTION
## Context

This issue was reproduced with:

- PowerSync v2.12.967
- Home Assistant custom integration: [SolarEdge Modbus Multi](https://github.com/WillCodeForCats/solaredge-modbus-multi) v3.3.2

PowerSync uses entities exposed by SolarEdge Modbus Multi for battery dispatch. This is separate from PowerSync's direct Modbus TCP path for inverter curtailment.

## What I was trying to do

Manual Force Charge should select `Charge from Solar Power and Grid` for the requested duration, then return the battery to normal operation.

The requested command became active, but PowerSync reported the operation as failed and ran its rollback path.

## What the logs showed

The logs pointed to four steps in the failure:

1. Control discovery matched entities by suffix without confirming their purpose. This allowed `*_limit_control_mode`, which controls production or export limits, to satisfy the Storage Control Mode role.

2. An unavailable `*_ac_charge_limit` with an unusable range could be selected instead of the writable `*_storage_charge_limit`.

3. Some Home Assistant service calls raised Modbus timeout or transaction ID errors, although Home Assistant reflected the requested entity state shortly afterwards.

4. PowerSync treated each service-call exception as a rejected command, so an otherwise accepted Force Charge operation entered rollback.

## First fix: continue control discovery

Telemetry discovery and the existing entity-ranking rules are unchanged.

Writable controls now resolve one existing suffix at a time. If the selected candidate is unavailable, has an unusable numeric range, or is not a storage-control selector, discovery continues to the next existing suffix.

This means Storage Charge Limit remains preferred, while a usable existing charge-limit alias remains available as a fallback. The change does not add new inverter-selection or multi-inverter rules.

A configured entity prefix may also include the optional trailing wildcard accepted by the existing configuration field.

## Follow-up fix: ambiguous Modbus outcomes

The Modbus transport and retry behaviour are unchanged.

When a Home Assistant select or number service call raises, PowerSync waits for up to three seconds for the requested entity state to appear. If Home Assistant reflects that state, the write is accepted. If it does not, the existing failure and rollback path remains in place.

AC Charge Policy is treated as optional when Storage Command Mode explicitly requests `Charge from Solar Power and Grid`. Failure of that policy write is logged without cancelling the explicit storage command.

## Validation

- Focused SolarEdge controller suite: 30 passed. This covers suffix fallback, invalid-candidate rejection, existing charge-limit compatibility, exact grid-charge selection, optional AC policy and reflected-state handling.
- Broader affected regression suite: 223 passed. This covers the SolarEdge runtime and shared force-mode, restore and teardown paths.
- Live validation confirmed that discovery selected Storage Charge Limit and left the unavailable AC Charge Limit untouched. It also showed that some requested states appeared after the three-second confirmation window had expired, so Force Charge still entered rollback. The restore path returned the battery to normal operation. This PR remains a draft while that confirmation window is resolved.

## Documentation

The main documentation was reviewed. No update is needed because this changes entity selection and ambiguous-write handling, not configuration or user-facing behaviour.