### PR TITLE
fix(frontend): stop forecast-summary & battery-health leaking detached DOM nodes

### DIFF
--- a/custom_components/power_sync/frontend/power-sync-strategy.js
+++ b/custom_components/power_sync/frontend/power-sync-strategy.js
@@ -1205,7 +1205,11 @@ class PowerSyncForecastSummary extends HTMLElement {
     if (!this._config || !this._hass) return;
 
     const items = Array.isArray(this._config.items) ? this._config.items : [];
-    this.shadowRoot.innerHTML = `
+    // LEAK FIX: only touch the DOM when the rendered output actually changed.
+    // set hass fires on EVERY state change (constant with the 2s local poll);
+    // the old code rebuilt this whole subtree every time, orphaning ha-icon /
+    // DOM nodes that accumulated (~15k detached nodes/min in testing).
+    const html = `
       <style>
         ha-card {
           padding: 14px;
@@ -1299,6 +1303,9 @@ class PowerSyncForecastSummary extends HTMLElement {
         </div>
       </ha-card>
     `;
+    if (html === this._lastRenderedHtml) return;
+    this._lastRenderedHtml = html;
+    this.shadowRoot.innerHTML = html;
   }
 
   _renderMetric(item) {
@@ -1403,7 +1410,9 @@ class PowerSyncBatteryHealth extends HTMLElement {
     const hasFollower = packs.some(pack => pack.role === 'follower' || pack.isFollower);
     const available = Number.isFinite(displayHealth) || hasCapacity || packs.length > 0;
 
-    this.shadowRoot.innerHTML = `
+    // LEAK FIX: build HTML and only write the DOM when it changed (same as
+    // forecast-summary) — avoids rebuilding this subtree on every 2s hass update.
+    const html = `
       <style>
         ha-card {
           overflow: hidden;
@@ -1656,6 +1665,9 @@ class PowerSyncBatteryHealth extends HTMLElement {
         </div>
       </ha-card>
     `;
+    if (html === this._lastRenderedHtml) return;
+    this._lastRenderedHtml = html;
+    this.shadowRoot.innerHTML = html;
   }
 
   _packRows(attrs) {


### PR DESCRIPTION
# Fix: dashboard cards leak detached DOM nodes (Chrome → ~10 GB over 6 hours)

## Summary
Two dashboard cards — `power-sync-forecast-summary` and `power-sync-battery-health` —
rebuild their entire `shadowRoot.innerHTML` on **every** `hass` update. Because
`hass` updates fire on every entity state change (and the local Powerwall poll runs
every 2 s — `POWERWALL_LOCAL_POLL_INTERVAL = 2`), the full subtree (including
`<ha-icon>` custom elements) is torn down and recreated constantly. The orphaned
nodes are retained and accumulate, so the Chrome renderer grows without bound.

## Symptom
- A dedicated PC left on the PowerSync dashboard (default `/power-sync/energy` view),
  nothing else running: Chrome process grew from ~600 MB to **~10 GB over 6 hours**,
  with periodic multi-GB transient spikes.

## Root cause (measured)
Using Chrome DevTools Protocol `Performance.getMetrics` on an idle dashboard:

| State | `Nodes` growth |
|---|---|
| Baseline (all cards) | **18,194 / min** |
| `forecast-summary` + `battery-health` render disabled | 2,690 / min (**−85%**) |
| + the 5 `power-sync-chart` cards disabled | 1,599 / min |

`Nodes` (renderer-tracked, incl. detached) climbed ~430/s while *attached* nodes
stayed flat (~2,400) and the JS heap sawtoothed normally (GC'd). So the growth is
**retained detached DOM**, which lives largely outside the JS heap — hence the JS
heap looked healthy (~100 MB) while the process ballooned to 10 GB.

The two cards' `set hass` → `_render()` unconditionally do
`this.shadowRoot.innerHTML = \`…\``. `PowerSyncChart` already guards its renders
(change-detection); these two do not.

## Fix
In both cards' `_render()`, build the HTML into a string and only write the DOM when
it actually changed (`_lastRenderedHtml` guard). Values change slowly, so the vast
majority of updates become no-ops — no teardown/rebuild, no orphaned nodes — while
any real value change still re-renders (no stale data).

## Validation (same CDP method, patch deployed)
- Guard confirmed loaded in both card prototypes after a cache-bust reload.
- Node growth: **18,194 → 2,160 / min (~88% reduction)**; listener growth ~250 → 46 / min.
- Remaining ~2.2k/min is the 5 chart cards + other cards (secondary).

## Notes / not in this PR
- The transport to the Powerwall gateway is healthy (TCP/TLS/HTTP probes: sub-second,
  0% loss) — the timeouts seen elsewhere are the heavy authenticated PW3 snapshot, not
  the network. Mentioned only so this isn't confused with a connectivity issue.
- Secondary: `power-sync-chart` fetches `history/period` with `significant_changes_only=0`
  over a midnight-anchored window that grows all day, re-fetched every ~5 min — worth a
  follow-up (downsample / `significant_changes_only=1` / rolling window), amplified by the
  2 s poll. Not addressed here to keep this PR focused.
- The same output-diff guard could be applied to the other `innerHTML`-rebuild cards.

## Downsides
- Negligible. `_render` still builds the HTML string each update (cheap); it only skips
  the expensive DOM write. No stale data (any change re-renders). The one theoretical
  caveat of output-diffing — relative-time text not ticking until data changes — does not
  apply, as these cards render absolute values/dates.
