### PR TITLE
Fix SolarEdge self-consumption baseline classification

### DIFF
--- a/custom_components/power_sync/inverters/solaredge.py
+++ b/custom_components/power_sync/inverters/solaredge.py
@@ -862,11 +862,8 @@ class SolarEdgeEnergyController:
         if command in active_commands:
             return True
 
-        try:
-            timeout = float(saved.get("command_timeout") or 0)
-        except (TypeError, ValueError):
-            timeout = 0
-        return timeout > 0
+        # A configured lease does not activate a benign storage command.
+        return False
 
     async def set_backup_reserve(self, percent: int) -> bool:
         """Set SolarEdge backup reserve / minimum SOC when exposed by HA."""

--- a/custom_components/power_sync/inverters/solaredge.py
+++ b/custom_components/power_sync/inverters/solaredge.py
@@ -857,7 +857,16 @@ class SolarEdgeEnergyController:
         command = _normalize_option(str(saved.get("storage_command_mode") or ""))
         active_commands = {
             _normalize_option(alias)
-            for alias in (*_CHARGE_OPTIONS, *_DISCHARGE_OPTIONS)
+            for alias in (
+                *_CHARGE_OPTIONS,
+                *_DISCHARGE_OPTIONS,
+                # Native active modes extend beyond the force-selection aliases.
+                "Charge from Clipped Solar Power",
+                "Charge from Solar Power",
+                "Charge from Solar Power and Grid",
+                "Discharge to Maximize Export",
+                "Discharge to Minimize Import",
+            )
         }
         if command in active_commands:
             return True

--- a/tests/test_solaredge_controller.py
+++ b/tests/test_solaredge_controller.py
@@ -1381,3 +1381,15 @@ def test_solaredge_missing_control_entities_keeps_telemetry_but_rejects_dispatch
     ]
     assert not asyncio.run(controller.force_charge(duration_minutes=30, power_w=4200))
     assert hass.services.calls == []
+
+
+def test_solaredge_benign_msc_timeout_is_not_active_dispatch():
+    controller = SolarEdgeEnergyController(_SEHass(), entity_prefix="solaredge")
+    controller._saved_control_state = {
+        "storage_control_mode": "Remote Control",
+        "storage_command_mode": "Maximize Self Consumption",
+        "charge_power_limit": "11400",
+        "discharge_power_limit": "11400",
+        "command_timeout": "3600",
+    }
+    assert not controller._saved_control_state_contains_active_dispatch()

--- a/tests/test_solaredge_controller.py
+++ b/tests/test_solaredge_controller.py
@@ -1393,3 +1393,58 @@ def test_solaredge_benign_msc_timeout_is_not_active_dispatch():
         "command_timeout": "3600",
     }
     assert not controller._saved_control_state_contains_active_dispatch()
+
+
+@pytest.mark.parametrize("command", [
+    "Charge from Clipped Solar Power",
+    "Charge from Solar Power",
+    "Charge from Solar Power and Grid",
+    "Discharge to Maximize Export",
+    "Discharge to Minimize Import",
+])
+@pytest.mark.parametrize("timeout", [0, 5400])
+def test_native_active_baseline_is_not_reapplied_after_force_charge(command, timeout):
+    hass = _SEHass()
+    command_state = hass.states.get("select.solaredge_storage_command_mode")
+    command_state.attributes["options"] = [
+        "Stop", "Charge from Solar Power and Grid", command,
+        "Maximize Self Consumption", "Solar Power Only (Off)",
+    ]
+    command_state.state = command
+    hass.states.get("select.solaredge_storage_control_mode").state = "Remote Control"
+    hass.states.get("number.solaredge_storage_discharge_limit").state = "4200"
+    hass.states.get("number.solaredge_storage_command_timeout").state = str(timeout)
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert asyncio.run(controller.force_charge(15, 2000))
+    assert controller._saved_control_state["storage_command_mode"] == command
+    hass.services.calls.clear()
+
+    assert asyncio.run(controller.restore_normal())
+    assert command_state.state == "Stop"
+    assert hass.states.get("select.solaredge_storage_control_mode").state == "Maximize Self Consumption"
+    assert float(hass.states.get("number.solaredge_storage_command_timeout").state) == 0
+    assert not any(data.get("option") == command for _, _, data in hass.services.calls)
+
+
+@pytest.mark.parametrize("command", ["Maximize Self Consumption", "Solar Power Only (Off)"])
+def test_native_benign_baseline_round_trip_preserves_nonzero_timeout(command):
+    hass = _SEHass()
+    command_state = hass.states.get("select.solaredge_storage_command_mode")
+    command_state.attributes["options"] = [command, "Charge from Solar Power and Grid", "Stop"]
+    command_state.state = command
+    hass.states.get("select.solaredge_storage_control_mode").state = "Remote Control"
+    for field in ("charge_limit", "discharge_limit"):
+        hass.states.get(f"number.solaredge_storage_{field}").state = "4200"
+    hass.states.get("number.solaredge_storage_command_timeout").state = "3600"
+    controller = SolarEdgeEnergyController(hass, entity_prefix="solaredge")
+
+    assert asyncio.run(controller.connect())
+    assert asyncio.run(controller.force_charge(15, 2000))
+    assert asyncio.run(controller.restore_normal())
+    assert command_state.state == command
+    assert hass.states.get("select.solaredge_storage_control_mode").state == "Remote Control"
+    for field in ("charge_limit", "discharge_limit"):
+        assert float(hass.states.get(f"number.solaredge_storage_{field}").state) == 4200
+    assert float(hass.states.get("number.solaredge_storage_command_timeout").state) == 3600


### PR DESCRIPTION
PowerSync treated any non-zero SolarEdge command timeout as evidence of active dispatch. A normal self-consumption configuration can retain a non-zero timeout, so this could reject a valid saved baseline during restoration.

Classify the baseline by its command mode. Active charging and discharging modes remain active; a configured timeout alone does not make self-consumption active.

Added a regression for self-consumption with a non-zero timeout. It fails on the parent and passes with this change.

Validation: `python -m pytest tests/test_solaredge_controller.py -q`: 51 passed. `git diff --check` passed.

This PR changes the classification and its regression test only.